### PR TITLE
Constrain the window's aspect ratio

### DIFF
--- a/RecastDemo/Source/main.cpp
+++ b/RecastDemo/Source/main.cpp
@@ -101,7 +101,8 @@ int main(int /*argc*/, char** /*argv*/)
 	}
 	else
 	{	
-		width = vi->current_w - 20;
+		width = rcMin(vi->current_w, (int)(vi->current_h * 16.0 / 9.0));
+		width = width - 80;
 		height = vi->current_h - 80;
 		screen = SDL_SetVideoMode(width, height, 0, SDL_OPENGL);
 	}


### PR DESCRIPTION
I was seeing the RecastDemo window span the full width of both of my monitors under Linux.

SDL 1.2 does not appear to provide detailed information about multi-monitor configuration, so I've applied the following changes to get a better starting size:
- Prevent the window from having an aspect ratio wider than 16:9
- Reduce both the width and the height by 80 pixels (I keep my task bar on the right)

This makes the RecastDemo window size more useful for me. I can't see that it would be significantly worse for other monitor configurations.
