### PR TITLE
Add partial path result status for dtCrowdAgent

### DIFF
--- a/DetourCrowd/Include/DetourCrowd.h
+++ b/DetourCrowd/Include/DetourCrowd.h
@@ -121,8 +121,8 @@ struct dtCrowdAgent
 	/// The type of mesh polygon the agent is traversing. (See: #CrowdAgentState)
 	unsigned char state;
 
-	/// 1 if the path is a partial path (the path does not lead to the target)
-	unsigned char partial;
+	/// True if the agent has valid path (targetState == DT_CROWDAGENT_TARGET_VALID) and the path does not lead to the requested position, else false.
+	bool partial;
 
 	/// The path corridor the agent is using.
 	dtPathCorridor corridor;

--- a/DetourCrowd/Source/DetourPathQueue.cpp
+++ b/DetourCrowd/Source/DetourPathQueue.cpp
@@ -185,7 +185,7 @@ dtStatus dtPathQueue::getPathResult(dtPathQueueRef ref, dtPolyRef* path, int* pa
 		if (m_queue[i].ref == ref)
 		{
 			PathQuery& q = m_queue[i];
-			dtStatus details = q.status;
+			dtStatus details = q.status & DT_STATUS_DETAIL_MASK;
 			// Free request for reuse.
 			q.ref = DT_PATHQ_INVALID;
 			q.status = 0;


### PR DESCRIPTION
This adds a flag which can be checked to see if the dtCrowdAgent has found a path that leads to the target or not.
