### PR TITLE
made dtQueryFilter members protected instead of private

### DIFF
--- a/Detour/Include/DetourNavMeshQuery.h
+++ b/Detour/Include/DetourNavMeshQuery.h
@@ -34,6 +34,7 @@
 /// @ingroup detour
 class dtQueryFilter
 {
+protected:
 	float m_areaCost[DT_MAX_AREAS];		///< Cost per area type. (Used by default implementation.)
 	unsigned short m_includeFlags;		///< Flags for polygons that can be visited. (Used by default implementation.)
 	unsigned short m_excludeFlags;		///< Flags for polygons that should not be visted. (Used by default implementation.)


### PR DESCRIPTION
It's very common for a derived class to need access to the members when extending getCost for example.
