### PR TITLE
More virtual destructors

### DIFF
--- a/DetourTileCache/Include/DetourTileCache.h
+++ b/DetourTileCache/Include/DetourTileCache.h
@@ -63,6 +63,8 @@ struct dtTileCacheParams
 
 struct dtTileCacheMeshProcess
 {
+	virtual ~dtTileCacheMeshProcess() { }
+
 	virtual void process(struct dtNavMeshCreateParams* params,
 						 unsigned char* polyAreas, unsigned short* polyFlags) = 0;
 };

--- a/DetourTileCache/Include/DetourTileCacheBuilder.h
+++ b/DetourTileCache/Include/DetourTileCacheBuilder.h
@@ -97,6 +97,8 @@ struct dtTileCacheAlloc
 
 struct dtTileCacheCompressor
 {
+	virtual ~dtTileCacheCompressor() { }
+
 	virtual int maxCompressedSize(const int bufferSize) = 0;
 	virtual dtStatus compress(const unsigned char* buffer, const int bufferSize,
 							  unsigned char* compressed, const int maxCompressedSize, int* compressedSize) = 0;


### PR DESCRIPTION
I'm writing some bindings for .NET usage of R&D so I'm going through the entire library. I found a few more missing virtual destructors.

By the way, I believe LinearAllocator in the demo is leaking memory because of this.
EDIT: Nevermind, you store a pointer to LinearAllocator, not to dtTileCacheAlloc.
