### PR TITLE
Bug fix to the any angle path

### DIFF
--- a/Detour/Source/DetourNavMeshQuery.cpp
+++ b/Detour/Source/DetourNavMeshQuery.cpp
@@ -2401,7 +2401,7 @@ dtStatus dtNavMeshQuery::raycast(dtPolyRef startRef, const float* startPos, cons
 	nextTile = prevTile = tile;
 	nextPoly = prevPoly = poly;
 	if (prevRef)
-		m_nav->getTileAndPolyByRefUnsafe(prevRef, &tile, &poly);
+		m_nav->getTileAndPolyByRefUnsafe(prevRef, &prevTile, &prevPoly);
 
 	while (curRef)
 	{


### PR DESCRIPTION
a one line fix...
A little type (using current tile instead of prevTile) caused the new raycast (with costs) to spew bad results and the any angle path to sometimes fail.
