### PR TITLE
Removed the multiple dtNode per poly for tile boundaries

### DIFF
--- a/DetourCrowd/Source/DetourPathCorridor.cpp
+++ b/DetourCrowd/Source/DetourPathCorridor.cpp
@@ -359,7 +359,7 @@ bool dtPathCorridor::optimizePathTopology(dtNavMeshQuery* navquery, const dtQuer
 	if (m_npath < 3)
 		return false;
 	
-	static const int MAX_ITER = 48;
+	static const int MAX_ITER = 32;
 	static const int MAX_RES = 32;
 	
 	dtPolyRef res[MAX_RES];


### PR DESCRIPTION
Removed the creation of multiple dtNodes per dtPolyRef at tile boundaries. Back to one node per poly.
The any angle part remains. Returned MAX_ITER of optimizeTopology back to 32.
