### PR TITLE
Removed superflous memset

### DIFF
--- a/Recast/Source/RecastLayers.cpp
+++ b/Recast/Source/RecastLayers.cpp
@@ -481,10 +481,8 @@ bool rcBuildHeightfieldLayers(rcContext* ctx, rcCompactHeightfield& chf,
 	for (int i = 0; i < lset.nlayers; ++i)
 	{
 		unsigned char curId = (unsigned char)i;
-		
-		// Allocate memory for the current layer.
+
 		rcHeightfieldLayer* layer = &lset.layers[i];
-		memset(layer, 0, sizeof(rcHeightfieldLayer));
 
 		const int gridSize = sizeof(unsigned char)*lw*lh;
 


### PR DESCRIPTION
We have already filled whole set of layers with zeroes at line 477. It looks like we don't need to fill the layers once again. Right?

Removed obsolete comment as well
