### PR TITLE
DetourNode: Change node index from unsigned short to unsigned int.

### DIFF
--- a/Detour/Include/DetourNode.h
+++ b/Detour/Include/DetourNode.h
@@ -28,7 +28,7 @@ enum dtNodeFlags
 	DT_NODE_PARENT_DETACHED = 0x04, // parent of the node is not adjacent. Found using raycast.
 };
 
-typedef unsigned short dtNodeIndex;
+typedef unsigned int dtNodeIndex;
 static const dtNodeIndex DT_NULL_IDX = (dtNodeIndex)~0;
 
 struct dtNode


### PR DESCRIPTION
On large tiled maps with high precision we could run out of indexs and detour would get stuck in an infinite loop.

Fixes: https://github.com/memononen/recastnavigation/issues/45
