### PR TITLE
DetourAlloc: Use size_t instead of int to better match the amount of memory we could allocate.

### DIFF
--- a/Detour/Include/DetourAlloc.h
+++ b/Detour/Include/DetourAlloc.h
@@ -32,7 +32,7 @@ enum dtAllocHint
 //  @param[in]		rcAllocHint	A hint to the allocator on how long the memory is expected to be in use.
 //  @return A pointer to the beginning of the allocated memory block, or null if the allocation failed.
 ///  @see dtAllocSetCustom
-typedef void* (dtAllocFunc)(int size, dtAllocHint hint);
+typedef void* (dtAllocFunc)(size_t size, dtAllocHint hint);
 
 /// A memory deallocation function.
 ///  @param[in]		ptr		A pointer to a memory block previously allocated using #dtAllocFunc.
@@ -49,7 +49,7 @@ void dtAllocSetCustom(dtAllocFunc *allocFunc, dtFreeFunc *freeFunc);
 ///  @param[in]		hint	A hint to the allocator on how long the memory is expected to be in use.
 ///  @return A pointer to the beginning of the allocated memory block, or null if the allocation failed.
 /// @see dtFree
-void* dtAlloc(int size, dtAllocHint hint);
+void* dtAlloc(size_t size, dtAllocHint hint);
 
 /// Deallocates a memory block.
 ///  @param[in]		ptr		A pointer to a memory block previously allocated using #dtAlloc.

--- a/Detour/Source/DetourAlloc.cpp
+++ b/Detour/Source/DetourAlloc.cpp
@@ -19,7 +19,7 @@
 #include <stdlib.h>
 #include "DetourAlloc.h"
 
-static void *dtAllocDefault(int size, dtAllocHint)
+static void *dtAllocDefault(size_t size, dtAllocHint)
 {
 	return malloc(size);
 }
@@ -38,7 +38,7 @@ void dtAllocSetCustom(dtAllocFunc *allocFunc, dtFreeFunc *freeFunc)
 	sFreeFunc = freeFunc ? freeFunc : dtFreeDefault;
 }
 
-void* dtAlloc(int size, dtAllocHint hint)
+void* dtAlloc(size_t size, dtAllocHint hint)
 {
 	return sAllocFunc(size, hint);
 }


### PR DESCRIPTION
...