### PR TITLE
Replaced FileList class with std::vector<std::string>

### DIFF
--- a/RecastDemo/Include/ChunkyTriMesh.h
+++ b/RecastDemo/Include/ChunkyTriMesh.h
@@ -21,8 +21,10 @@
 
 struct rcChunkyTriMeshNode
 {
-	float bmin[2], bmax[2];
-	int i, n;
+	float bmin[2];
+	float bmax[2];
+	int i;
+	int n;
 };
 
 struct rcChunkyTriMesh

--- a/RecastDemo/Include/Filelist.h
+++ b/RecastDemo/Include/Filelist.h
@@ -19,17 +19,9 @@
 #ifndef FILELIST_H
 #define FILELIST_H
 
-struct FileList
-{
-	static const int MAX_FILES = 256;
-	
-	FileList();
-	~FileList();
-	
-	char* files[MAX_FILES];
-	int size;
-};
+#include <vector>
+#include <string>
 
-void scanDirectory(const char* path, const char* ext, FileList& list);
+void scanDirectory(std::string path, std::string ext, std::vector<std::string>& fileList);
 
 #endif // FILELIST_H

--- a/RecastDemo/Include/SlideShow.h
+++ b/RecastDemo/Include/SlideShow.h
@@ -20,10 +20,12 @@
 #define SLIDESHOW_H
 
 #include "Filelist.h"
+#include <vector>
+#include <string>
 
 class SlideShow
 {
-	FileList m_files;
+	std::vector<std::string> m_files;
 	char m_path[256];
 
 	int m_width;

--- a/RecastDemo/Source/SlideShow.cpp
+++ b/RecastDemo/Source/SlideShow.cpp
@@ -17,6 +17,7 @@
 //
 
 #include "SlideShow.h"
+
 #include <string.h>
 #include <stdio.h>
 #include "SDL_opengl.h"
@@ -98,7 +99,7 @@ void SlideShow::prevSlide()
 
 void SlideShow::setSlide(int n)
 {
-	const int maxIdx = m_files.size ? m_files.size-1 : 0;
+	const int maxIdx = m_files.size() ? m_files.size() - 1 : 0;
 	m_nextSlide = n;
 	if (m_nextSlide < 0) m_nextSlide = 0;
 	if (m_nextSlide > maxIdx) m_nextSlide = maxIdx; 
@@ -120,11 +121,11 @@ void SlideShow::updateAndDraw(float dt, const float w, const float h)
 	if (m_curSlide != m_nextSlide && m_slideAlpha < 0.01f)
 	{
 		m_curSlide = m_nextSlide;
-		if (m_curSlide >= 0 && m_curSlide < m_files.size)
+		if (m_curSlide >= 0 && static_cast<std::size_t>(m_curSlide) < m_files.size())
 		{
 			char path[256];
 			strcpy(path, m_path);
-			strcat(path, m_files.files[m_curSlide]);
+			strcat(path, m_files[m_curSlide].c_str());
 			loadImage(path);
 		}
 	}

--- a/RecastDemo/Source/main.cpp
+++ b/RecastDemo/Source/main.cpp
@@ -28,6 +28,9 @@
 #	include <GL/glu.h>
 #endif
 
+#include <vector>
+#include <string>
+
 #include "imgui.h"
 #include "imguiRenderGL.h"
 
@@ -46,6 +49,9 @@
 #	define snprintf _snprintf
 #	define putenv _putenv
 #endif
+
+using std::string;
+using std::vector;
 
 struct SampleItem
 {
@@ -163,7 +169,7 @@ int main(int /*argc*/, char** /*argv*/)
 	
 	char sampleName[64] = "Choose Sample..."; 
 	
-	FileList files;
+	vector<string> files;
 	char meshName[128] = "Choose Mesh...";
 	
 	float markerPosition[3] = {0, 0, 0};
@@ -714,16 +720,20 @@ int main(int /*argc*/, char** /*argv*/)
 			if (imguiBeginScrollArea("Choose Level", width - 10 - 250 - 10 - 200, height - 10 - 450, 200, 450, &levelScroll))
 				mouseOverMenu = true;
 			
-			int levelToLoad = -1;
-			for (int i = 0; i < files.size; ++i)
+			vector<string>::const_iterator fileIter = files.begin();
+			vector<string>::const_iterator filesEnd = files.end();
+			vector<string>::const_iterator levelToLoad = filesEnd;
+			for (; fileIter != filesEnd; ++fileIter)
 			{
-				if (imguiItem(files.files[i]))
-					levelToLoad = i;
+				if (imguiItem(fileIter->c_str()))
+				{
+					levelToLoad = fileIter;
+				}
 			}
 			
-			if (levelToLoad != -1)
+			if (levelToLoad != filesEnd)
 			{
-				strncpy(meshName, files.files[levelToLoad], sizeof(meshName));
+				strncpy(meshName, levelToLoad->c_str(), sizeof(meshName));
 				meshName[sizeof(meshName)-1] = '\0';
 				showLevels = false;
 				
@@ -792,18 +802,22 @@ int main(int /*argc*/, char** /*argv*/)
 			if (imguiBeginScrollArea("Choose Test To Run", width-10-250-10-200, height-10-450, 200, 450, &testScroll))
 				mouseOverMenu = true;
 
-			int testToLoad = -1;
-			for (int i = 0; i < files.size; ++i)
+			vector<string>::const_iterator fileIter = files.begin();
+			vector<string>::const_iterator filesEnd = files.end();
+			vector<string>::const_iterator testToLoad = filesEnd;
+			for (; fileIter != filesEnd; ++fileIter)
 			{
-				if (imguiItem(files.files[i]))
-					testToLoad = i;
+				if (imguiItem(fileIter->c_str()))
+				{
+					testToLoad = fileIter;
+				}
 			}
 			
-			if (testToLoad != -1)
+			if (testToLoad != filesEnd)
 			{
 				char path[256];
 				strcpy(path, "TestCases/");
-				strcat(path, files.files[testToLoad]);
+				strcat(path, testToLoad->c_str());
 				test = new TestCase;
 				if (test)
 				{


### PR DESCRIPTION
The goals of the demo project (as I see it at least) are to:
1.  Showcase Recast and Detour's capabilities and flexibility
2.  Provide a clear example of how to correctly interact with the Recast and Detour API's
3.  Provide a flexible base on which people can build proprietary tools.

The demo project doesn't have the same dependency restrictions as Detour and Recast, and benefits more from clarity and flexibility.  I feel like using STL is an improvement in both these areas over hand-rolled collections and c-style strings.  To be clear, I feel this only applies to the demo project, and not Recast and Detour as a whole.

I'd love to hear people's input on this, especially if they disagree.