### PR TITLE
Make max number of convex volumes configurable

### DIFF
--- a/RecastDemo/Include/InputGeom.h
+++ b/RecastDemo/Include/InputGeom.h
@@ -51,13 +51,13 @@ class InputGeom
 
 	/// @name Convex Volumes.
 	///@{
-	static const int MAX_VOLUMES = 256;
-	ConvexVolume m_volumes[MAX_VOLUMES];
+	ConvexVolume * m_volumes;
+	const int m_maxVolumes;
 	int m_volumeCount;
 	///@}
 	
 public:
-	InputGeom();
+	InputGeom(int maxvolumes = 256);
 	~InputGeom();
 	
 	bool loadMesh(class rcContext* ctx, const char* filepath);

--- a/RecastDemo/Source/InputGeom.cpp
+++ b/RecastDemo/Source/InputGeom.cpp
@@ -104,18 +104,21 @@ static char* parseRow(char* buf, char* bufEnd, char* row, int len)
 
 
 
-InputGeom::InputGeom() :
+InputGeom::InputGeom(int maxvolumes) :
 	m_chunkyMesh(0),
 	m_mesh(0),
 	m_offMeshConCount(0),
+	m_maxVolumes(maxvolumes),
 	m_volumeCount(0)
 {
+	m_volumes = new ConvexVolume[m_maxVolumes];
 }
 
 InputGeom::~InputGeom()
 {
 	delete m_chunkyMesh;
 	delete m_mesh;
+	delete m_volumes;
 }
 		
 bool InputGeom::loadMesh(rcContext* ctx, const char* filepath)
@@ -231,7 +234,7 @@ bool InputGeom::load(rcContext* ctx, const char* filePath)
 		else if (row[0] == 'v')
 		{
 			// Convex volumes
-			if (m_volumeCount < MAX_VOLUMES)
+			if (m_volumeCount < m_maxVolumes)
 			{
 				ConvexVolume* vol = &m_volumes[m_volumeCount++];
 				sscanf(row+1, "%d %d %f %f", &vol->nverts, &vol->area, &vol->hmin, &vol->hmax);
@@ -432,7 +435,7 @@ void InputGeom::drawOffMeshConnections(duDebugDraw* dd, bool hilight)
 void InputGeom::addConvexVolume(const float* verts, const int nverts,
 								const float minh, const float maxh, unsigned char area)
 {
-	if (m_volumeCount >= MAX_VOLUMES) return;
+	if (m_volumeCount >= m_maxVolumes) return;
 	ConvexVolume* vol = &m_volumes[m_volumeCount++];
 	memset(vol, 0, sizeof(ConvexVolume));
 	memcpy(vol->verts, verts, sizeof(float)*3*nverts);


### PR DESCRIPTION
This removes the arbitrary max upper limit of 256 in case you need a very large number.

The background for this change is that @JeanPierreC and I ran into an issue with a nav mesh we were building that required several thousand convex volumes to represent our road network. We had been using `InputGeom.h/cpp` directly from the _RecastDemo_ in our project and this is the fix we required. We had originally just tried increasing `MAX_VOLUMES` to what we needed (32768), but that blew the 1MB stack size pretty easily. So instead we went with this solution to dynamically allocate space for the volumes on the heap. We can now can guarantee there'll be exactly enough convex volumes rather the hard coded limit to bump into.

This change shouldn't be noticable to the _RecastDemo_, the default number of volumes is still 256, but we thought if someone else is like us and uses the _RecastDemo_ source code as the basis for their project this may be useful to them.
