### PR TITLE
RecastDemo Allow the camera to be rotated on the X axis using Q and E.

### DIFF
--- a/RecastDemo/Source/main.cpp
+++ b/RecastDemo/Source/main.cpp
@@ -477,6 +477,11 @@ int main(int /*argc*/, char** /*argv*/)
 		float keybSpeed = 22.0f;
 		if (SDL_GetModState() & KMOD_SHIFT)
 			keybSpeed *= 4.0f;
+			
+		if (keystate[SDLK_q])
+            		ry = fmod(ry - dt * 4 * keybSpeed, 360.0f) - 360.0f;
+        	if (keystate[SDLK_e])
+            		ry = fmod(ry + dt * 4 * keybSpeed, 360.0f) - 360.0f;
 		
 		float movex = (moveD - moveA) * keybSpeed * dt;
 		float movey = (moveS - moveW) * keybSpeed * dt;


### PR DESCRIPTION
This patch just allows to alter camera yaw using Q and E in complement of the mouse. I am not sure which keys to use to alter pitch. I tried X and space, but space would conflict with previously defined actions (that I personally do not need). Let me know what you think of it.