### PR TITLE
Old mesh tile not removed when new tile is empty (temp obstacles)

### DIFF
--- a/DetourTileCache/Source/DetourTileCache.cpp
+++ b/DetourTileCache/Source/DetourTileCache.cpp
@@ -631,7 +631,11 @@ dtStatus dtTileCache::buildNavMeshTile(const dtCompressedTileRef ref, dtNavMesh*
 	
 	// Early out if the mesh tile is empty.
 	if (!bc.lmesh->npolys)
+	{
+		// Remove existing tile.
+		navmesh->removeTile(navmesh->getTileRefAt(tile->header->tx,tile->header->ty,tile->header->tlayer),0,0);
 		return DT_SUCCESS;
+	}
 	
 	dtNavMeshCreateParams params;
 	memset(&params, 0, sizeof(params));


### PR DESCRIPTION
When a temp obstacle completely covers a tile, the old mesh tile is not removed.