### PR TITLE
Updated dtFindPathOptions description and options

### DIFF
--- a/Detour/Include/DetourNavMesh.h
+++ b/Detour/Include/DetourNavMesh.h
@@ -118,11 +118,10 @@ enum dtStraightPathOptions
 };
 
 
-/// Options for dtNavMeshQuery::findPath
+/// Options for dtNavMeshQuery::initSlicedFindPath and updateSlicedFindPath
 enum dtFindPathOptions
 {
-	DT_FINDPATH_LOW_QUALITY_FAR = 0x01,		///< [provisional] trade quality for performance far from the origin. The idea is that by then a new query will be issued
-	DT_FINDPATH_ANY_ANGLE	= 0x02,			///< use raycasts during pathfind to "shortcut" (raycast still consider costs)
+	DT_FINDPATH_ANY_ANGLE	= 0x02,		///< use raycasts during pathfind to "shortcut" (raycast still consider costs)
 };
 
 /// Options for dtNavMeshQuery::raycast


### PR DESCRIPTION
"Options for dtNavMeshQuery::FindPath" is not correct, the option is used in SlicedFindPath only
DT_FINDPATH_LOW_QUALITY_FAR is not used anywhere

I would also add, that even though raycast considers costs, does so not very well :-(