### PR TITLE
Add AppVeyor and Travis CI build scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+sudo: false
+
+language: cpp
+
+# Install SDL 1.2 development libraries.
+addons:
+  apt:
+    packages:
+    - libsdl1.2-dev
+
+# Build with gcc and clang.
+compiler:
+  - gcc
+# Disable clang for now since it seems there's a problem using it with fast fp math; it's likely Travis' ancient environment that's at fault.
+#  - clang
+
+# Build both debug and release configurations, through use of an environment variable in the build matrix.
+env:
+  - CONFIGURATION=debug
+  - CONFIGURATION=release
+
+install:
+  # Download and build premake5 from source; the Travis environment doesn't have the right version of glibc6 for the prebuilt binaries to work.
+  - wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha6/premake-5.0.0-alpha6-src.zip -O premake.zip
+  - unzip premake.zip
+  - cd premake-5.0.0-alpha6/build/gmake.unix
+  - make config=release
+  - cd ../../..
+  - mv premake-5.0.0-alpha6/bin/release/premake5 premake5
+
+# Run premake to generate makefiles.
+# Have to cd into directory and back out since premake5 doesn't appear to accept a directory argument.
+before_script:
+  - cd RecastDemo && ../premake5 gmake && cd ..
+
+# Run make in the directory containing generated makefiles, on the configuration specified by the environment variable.
+script:
+  - make -C RecastDemo/Build/gmake config=$CONFIGURATION

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 Recast & Detour
 ===============
 
+[![Travis (Linux) Build Status](https://travis-ci.org/hymerman/recastnavigation.svg?branch=continuous-integration-setup)](https://travis-ci.org/hymerman/recastnavigation)
+[![Appveyor (Windows) build status](https://ci.appveyor.com/api/projects/status/4s8cunkkp81hshyq/branch/continuous-integration-setup?svg=true)](https://ci.appveyor.com/project/hymerman/recastnavigation/branch/continuous-integration-setup)
+
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/memononen/recastnavigation/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
 
 ![screenshot of a navmesh baked with the sample program](/RecastDemo/screenshot.png?raw=true)
@@ -37,13 +40,13 @@ You can find a comprehensive demo project in RecastDemo folder. It is a kitchen 
 
 ### Building RecastDemo
 
-RecastDemo uses [premake4](http://industriousone.com/premake) to build platform specific projects, now is good time to install it if you don't have it already. To build *RecasDemo*, in your favorite terminal navigate into the `RecastDemo` folder, then:
+RecastDemo uses [premake5](http://premake.github.io/) to build platform specific projects. Download it and make sure it's available on your path, or specify the path to it. To build *RecastDemo*, in your favorite terminal navigate into the `RecastDemo` folder, then:
 
-- *OS X*: `premake4 xcode4`
-- *Windows*: `premake4 vs2010`
-- *Linux*: `premake4 gmake`
+- *OS X*: `premake5 xcode4`
+- *Windows*: `"premake5" vs2015`
+- *Linux*: `premake5 gmake`
 
-See premake4 documentation for full list of supported build file types. The projects will be created in `RecastDemo/Build` folder. And after you have compiled the project, the *RecastDemo* executable will be located in `RecastDemo/Bin` folder.
+See premake5 documentation for full list of supported build file types. The projects will be created in `RecastDemo/Build` folder. And after you have compiled the project, the *RecastDemo* executable will be located in `RecastDemo/Bin` folder.
 
 *Note:* On Windows, please use x86 version of the SDL.dll to run the demo Application. 
 

--- a/RecastDemo/Contrib/readme-sdl.txt
+++ b/RecastDemo/Contrib/readme-sdl.txt
@@ -1,6 +1,6 @@
 
 Windows
-Download SDL Developer Libraries from http://www.libsdl.org and unzip them here.
+Download SDL Developer Libraries from http://www.libsdl.org and unzip them to SDL/
 
 OSX
 Download and install OSX SDL Developer Libraries from http://www.libsdl.org

--- a/RecastDemo/premake5.lua
+++ b/RecastDemo/premake5.lua
@@ -1,6 +1,6 @@
 --
--- premake4 file to build RecastDemo
--- http://industriousone.com/premake
+-- premake5 file to build RecastDemo
+-- http://premake.github.io/
 --
 
 local action = _ACTION or ""

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,34 @@
+shallow_clone: true
+
+os:
+  - Visual Studio 2015
+
+environment:
+  matrix:
+  - TOOLSET: vs2010
+  - TOOLSET: vs2013
+  # Can't use vs2015 toolset yet as it appears SDL 1.2 has some link errors with it.
+  # - TOOLSET: vs2015
+
+install:
+  # Download Premake
+  - ps: Start-FileDownload 'https://github.com/premake/premake-core/releases/download/v5.0.0-alpha6/premake-5.0.0-alpha6-windows.zip' 'premake.zip'
+  
+  # Extract it in-place; premake5.exe is at the top level.
+  - 7z x premake.zip
+
+  # Download SDL.
+  - ps: Start-FileDownload 'https://www.libsdl.org/release/SDL-devel-1.2.15-VC.zip' 'RecastDemo/Contrib/SDL.zip'
+  
+  # Extract it and put it in the right place.
+  - cd RecastDemo/Contrib && 7z x SDL.zip && mv SDL-1.2.15 SDL && cd ../..
+  
+  # Generate solution files using premake.
+  - cd RecastDemo && "../premake5.exe" %TOOLSET% && cd ..
+
+configuration:
+  - Debug
+  - Release
+
+build:
+  project: RecastDemo/Build/$(TOOLSET)/recastnavigation.sln


### PR DESCRIPTION
Build scripts download SDL, download (or build) premake5, generate projects, then build, in several configurations and platforms

Project now builds with premake5 instead of premake4 to allow VS2015 project generation
Tweaked SDL directory dependency to work better with CI
Update README

This replaces my PR #89 - I wanted to create one new squashed commit rather than leave the messy history with checked in binaries.