### PR TITLE
Use intermediate variable for nearest point in findNearestPoly

### DIFF
--- a/Detour/Source/DetourNavMeshQuery.cpp
+++ b/Detour/Source/DetourNavMeshQuery.cpp
@@ -721,8 +721,13 @@ dtStatus dtNavMeshQuery::findNearestPoly(const float* center, const float* exten
 	if (dtStatusFailed(queryPolygons(center, extents, filter, polys, &polyCount, MAX_SEARCH)))
 		return DT_FAILURE | DT_INVALID_PARAM;
 	
+	if (polyCount == 0)
+		return DT_SUCCESS;
+	
 	// Find nearest polygon amongst the nearby polygons.
 	dtPolyRef nearest = 0;
+	float nearestPoint[3];
+
 	float nearestDistanceSqr = FLT_MAX;
 	for (int i = 0; i < polyCount; ++i)
 	{
@@ -751,15 +756,17 @@ dtStatus dtNavMeshQuery::findNearestPoly(const float* center, const float* exten
 		
 		if (d < nearestDistanceSqr)
 		{
-			if (nearestPt)
-				dtVcopy(nearestPt, closestPtPoly);
+			dtVcopy(nearestPoint, closestPtPoly);
+
 			nearestDistanceSqr = d;
 			nearest = ref;
 		}
 	}
 	
-	if (nearestRef)
-		*nearestRef = nearest;
+	*nearestRef = nearest;
+
+	if (nearestPt)
+		dtVcopy(nearestPt, nearestPoint);
 	
 	return DT_SUCCESS;
 }


### PR DESCRIPTION
When the same point is used as center and as nearestPt, the function
would override center and give wrong results.

Fix #118