### PR TITLE
Fix heap corruption when collecting region layers

### DIFF
--- a/Recast/Source/RecastLayers.cpp
+++ b/Recast/Source/RecastLayers.cpp
@@ -258,7 +258,7 @@ bool rcBuildHeightfieldLayers(rcContext* ctx, rcCompactHeightfield& chf,
 						const int ay = y + rcGetDirOffsetY(dir);
 						const int ai = (int)chf.cells[ax+ay*w].index + rcGetCon(s, dir);
 						const unsigned char rai = srcReg[ai];
-						if (rai != 0xff && rai != ri)
+						if (rai != 0xff && rai != ri && regs[ri].nneis < RC_MAX_NEIS)
 							addUnique(regs[ri].neis, regs[ri].nneis, rai);
 					}
 				}


### PR DESCRIPTION
This fix is the fix Mikko suggested in #30. However, I don't completely understand
the code here. As far as I can see, this code tries to identify which regions should be merged into what will finally become the layers. @memononen, can you try explaining why it's ok that we do not collect all of these regions? Would it not be better to expand the array to be able to collect all the neighbours? Or will this situation just introduce a few more layers, which is probably ok?

The collecting could overflow the neighbours array due to a missing boundary
check.

Fix #30 