### PR TITLE
Ensure SDL2.dll is copied for paths with spaces

### DIFF
--- a/RecastDemo/premake5.lua
+++ b/RecastDemo/premake5.lua
@@ -158,7 +158,7 @@ project "RecastDemo"
 		}
 		postbuildcommands {
 			-- Copy the SDL2 dll to the Bin folder.
-			"{COPY} %{wks.location}../../Contrib/SDL/lib/x86/SDL2.dll %{cfg.targetdir}"
+			'{COPY} "%{wks.location}../../Contrib/SDL/lib/x86/SDL2.dll" "%{cfg.targetdir}"'
 		}
 
 	-- mac includes and libs


### PR DESCRIPTION
Just a small fix for when the solution/bin path contains spaces. This was the only thing
preventing me from running it directly after premake generation.