### PR TITLE
Improve area and region ID selection for triangulated holes

### DIFF
--- a/Recast/Source/RecastMesh.cpp
+++ b/Recast/Source/RecastMesh.cpp
@@ -663,6 +663,16 @@ static bool canRemoveVertex(rcContext* ctx, rcPolyMesh& mesh, const unsigned sho
 	return true;
 }
 
+static int getCommonOrFirst(int val1, int val2, int val3)
+{
+	if (val1 == val2 || val1 == val3)
+		return val1;
+	if (val2 == val3)
+		return val2;
+
+	return val1;
+}
+
 static bool removeVertex(rcContext* ctx, rcPolyMesh& mesh, const unsigned short rem, const int maxTris)
 {
 	const int nvp = mesh.nvp;
@@ -895,8 +905,8 @@ static bool removeVertex(rcContext* ctx, rcPolyMesh& mesh, const unsigned short 
 			polys[npolys*nvp+0] = (unsigned short)hole[t[0]];
 			polys[npolys*nvp+1] = (unsigned short)hole[t[1]];
 			polys[npolys*nvp+2] = (unsigned short)hole[t[2]];
-			pregs[npolys] = (unsigned short)hreg[t[0]];
-			pareas[npolys] = (unsigned char)harea[t[0]];
+			pregs[npolys] = (unsigned short)getCommonOrFirst(hreg[t[0]], hreg[t[1]], hreg[t[2]]);
+			pareas[npolys] = (unsigned char)getCommonOrFirst(harea[t[0]], harea[t[1]], harea[t[2]]);
 			npolys++;
 		}
 	}


### PR DESCRIPTION
This improves on a case where Recast would assign a region and area ID
that did not end up matching the final poly mesh very well.
This would happen in cases where several vertices were shared by
polygons with different regions after removal of a border vertex.
This fix improves the case by selecting the most common region and
area ID instead of always using the first; this should resolve the
majority of these cases. See #146 for more detailed information.

This does not catch all situations; it's possible that vertex 3 (in the picture in the second post of #146) would be shared with a different polygon. In this case it would be possible that there was no common region/area ID. However, this fix should fix the majority of (already rare) cases.
A better solution would need to take into account the shared vertices and all their possible types. Maybe @memononen has some thoughts on a better solution?