### PR TITLE
Fix time measuring on Windows

### DIFF
--- a/RecastDemo/Include/PerfTimer.h
+++ b/RecastDemo/Include/PerfTimer.h
@@ -27,6 +27,6 @@ typedef __int64 TimeVal;
 #endif
 
 TimeVal getPerfTime();
-int getPerfDeltaTimeUsec(const TimeVal start, const TimeVal end);
+int getPerfTimeUsec(const TimeVal duration);
 
 #endif // PERFTIMER_H

--- a/RecastDemo/Include/SampleInterfaces.h
+++ b/RecastDemo/Include/SampleInterfaces.h
@@ -30,7 +30,7 @@
 class BuildContext : public rcContext
 {
 	TimeVal m_startTime[RC_MAX_TIMERS];
-	int m_accTime[RC_MAX_TIMERS];
+	TimeVal m_accTime[RC_MAX_TIMERS];
 
 	static const int MAX_MESSAGES = 1000;
 	const char* m_messages[MAX_MESSAGES];

--- a/RecastDemo/Source/CrowdTool.cpp
+++ b/RecastDemo/Source/CrowdTool.cpp
@@ -854,7 +854,7 @@ void CrowdToolState::updateTick(const float dt)
 	m_agentDebug.vod->normalizeSamples();
 	
 	m_crowdSampleCount.addSample((float)crowd->getVelocitySampleCount());
-	m_crowdTotalTime.addSample(getPerfDeltaTimeUsec(startTime, endTime) / 1000.0f);
+	m_crowdTotalTime.addSample(getPerfTimeUsec(endTime - startTime) / 1000.0f);
 }
 
 

--- a/RecastDemo/Source/PerfTimer.cpp
+++ b/RecastDemo/Source/PerfTimer.cpp
@@ -30,13 +30,12 @@ TimeVal getPerfTime()
 	return count;
 }
 
-int getPerfDeltaTimeUsec(const TimeVal start, const TimeVal end)
+int getPerfTimeUsec(const TimeVal duration)
 {
 	static __int64 freq = 0;
 	if (freq == 0)
 		QueryPerformanceFrequency((LARGE_INTEGER*)&freq);
-	__int64 elapsed = end - start;
-	return (int)(elapsed*1000000 / freq);
+	return (int)(duration*1000000 / freq);
 }
 
 #else
@@ -52,9 +51,9 @@ TimeVal getPerfTime()
 	return (TimeVal)now.tv_sec*1000000L + (TimeVal)now.tv_usec;
 }
 
-int getPerfDeltaTimeUsec(const TimeVal start, const TimeVal end)
+int getPerfTimeUsec(const TimeVal duration)
 {
-	return (int)(end - start);
+	return (int)duration;
 }
 
 #endif

--- a/RecastDemo/Source/SampleInterfaces.cpp
+++ b/RecastDemo/Source/SampleInterfaces.cpp
@@ -79,7 +79,7 @@ void BuildContext::doStopTimer(const rcTimerLabel label)
 
 int BuildContext::doGetAccumulatedTime(const rcTimerLabel label) const
 {
-	return m_accTime[label];
+	return getPerfTimeUsec(m_accTime[label]);
 }
 
 void BuildContext::dumpLog(const char* format, ...)

--- a/RecastDemo/Source/TestCase.cpp
+++ b/RecastDemo/Source/TestCase.cpp
@@ -215,7 +215,7 @@ void TestCase::doTests(dtNavMesh* navmesh, dtNavMeshQuery* navquery)
 		navquery->findNearestPoly(iter->epos, polyPickExt, &filter, &endRef, iter->nepos);
 
 		TimeVal findNearestPolyEnd = getPerfTime();
-		iter->findNearestPolyTime += getPerfDeltaTimeUsec(findNearestPolyStart, findNearestPolyEnd);
+		iter->findNearestPolyTime += getPerfTimeUsec(findNearestPolyEnd - findNearestPolyStart);
 
 		if (!startRef || ! endRef)
 			continue;
@@ -228,7 +228,7 @@ void TestCase::doTests(dtNavMesh* navmesh, dtNavMeshQuery* navquery)
 			navquery->findPath(startRef, endRef, iter->spos, iter->epos, &filter, polys, &iter->npolys, MAX_POLYS);
 			
 			TimeVal findPathEnd = getPerfTime();
-			iter->findPathTime += getPerfDeltaTimeUsec(findPathStart, findPathEnd);
+			iter->findPathTime += getPerfTimeUsec(findPathEnd - findPathStart);
 		
 			// Find straight path
 			if (iter->npolys)
@@ -238,7 +238,7 @@ void TestCase::doTests(dtNavMesh* navmesh, dtNavMeshQuery* navquery)
 				navquery->findStraightPath(iter->spos, iter->epos, polys, iter->npolys,
 										   straight, 0, 0, &iter->nstraight, MAX_POLYS);
 				TimeVal findStraightPathEnd = getPerfTime();
-				iter->findStraightPathTime += getPerfDeltaTimeUsec(findStraightPathStart, findStraightPathEnd);
+				iter->findStraightPathTime += getPerfTimeUsec(findStraightPathEnd - findStraightPathStart);
 			}
 		
 			// Copy results
@@ -270,7 +270,7 @@ void TestCase::doTests(dtNavMesh* navmesh, dtNavMeshQuery* navquery)
 			navquery->raycast(startRef, iter->spos, iter->epos, &filter, &t, hitNormal, polys, &iter->npolys, MAX_POLYS);
 
 			TimeVal findPathEnd = getPerfTime();
-			iter->findPathTime += getPerfDeltaTimeUsec(findPathStart, findPathEnd);
+			iter->findPathTime += getPerfTimeUsec(findPathEnd - findPathStart);
 
 			if (t > 1)
 			{


### PR DESCRIPTION
The demo relied on the build context returning accumulated times in
microseconds. On Windows this was using QueryPerformanceCounter directly
which has a higher resolution, thus returning wrong measured times. We
now report the accumulated times in microseconds on all platforms.