### PR TITLE
Remove BitDeli badge from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ Recast & Detour
 [![Travis (Linux) Build Status](https://travis-ci.org/recastnavigation/recastnavigation.svg?branch=master)](https://travis-ci.org/recastnavigation/recastnavigation)
 [![Appveyor (Windows) Build  Status](https://ci.appveyor.com/api/projects/status/20w84u25b3f8h179/branch/master?svg=true)](https://ci.appveyor.com/project/recastnavigation/recastnavigation/branch/master)
 
-[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/memononen/recastnavigation/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
-
 ![screenshot of a navmesh baked with the sample program](/RecastDemo/screenshot.png?raw=true)
 
 ## Recast


### PR DESCRIPTION
It appears that BitDeli is defunct; their website has had a banner about a change in the GitHub API for a long time, which is a dead link to a blog article, and none of the example stats have been updated for years. Let's just remove it!