### PR TITLE
Fix possible compile/link error with multiple BuildContext definitions

### DIFF
--- a/DetourTileCache/Source/DetourTileCache.cpp
+++ b/DetourTileCache/Source/DetourTileCache.cpp
@@ -40,10 +40,10 @@ inline int computeTileHash(int x, int y, const int mask)
 }
 
 
-struct BuildContext
+struct NavMeshTileBuildContext
 {
-	inline BuildContext(struct dtTileCacheAlloc* a) : layer(0), lcset(0), lmesh(0), alloc(a) {}
-	inline ~BuildContext() { purge(); }
+	inline NavMeshTileBuildContext(struct dtTileCacheAlloc* a) : layer(0), lcset(0), lmesh(0), alloc(a) {}
+	inline ~NavMeshTileBuildContext() { purge(); }
 	void purge()
 	{
 		dtFreeTileCacheLayer(alloc, layer);
@@ -587,7 +587,7 @@ dtStatus dtTileCache::buildNavMeshTile(const dtCompressedTileRef ref, dtNavMesh*
 	
 	m_talloc->reset();
 	
-	BuildContext bc(m_talloc);
+	NavMeshTileBuildContext bc(m_talloc);
 	const int walkableClimbVx = (int)(m_params.walkableClimb / m_params.ch);
 	dtStatus status;
 	


### PR DESCRIPTION
There is a class and a struct called BuildContext in two different files,
one .h and one .cpp. Depending on how the user structures their program,
it's possible that this would cause a compile or link error, as seems to
have happened in #44. I've just renamed the struct to get around this.

Fixes #44