### PR TITLE
Add settings storage to geometry sets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,8 @@ RecastDemo/Bin/Tests
 # Build directory
 RecastDemo/Build
 
-# Ignore some meshes based on name
-RecastDemo/Bin/Meshes/_*
+# Ignore meshes
+RecastDemo/Bin/Meshes/*
 
 ## Logs and databases #
 *.log

--- a/RecastDemo/Include/Filelist.h
+++ b/RecastDemo/Include/Filelist.h
@@ -22,6 +22,7 @@
 #include <vector>
 #include <string>
 
-void scanDirectory(std::string path, std::string ext, std::vector<std::string>& fileList);
+void scanDirectoryAppend(const std::string& path, const std::string& ext, std::vector<std::string>& fileList);
+void scanDirectory(const std::string& path, const std::string& ext, std::vector<std::string>& fileList);
 
 #endif // FILELIST_H

--- a/RecastDemo/Include/InputGeom.h
+++ b/RecastDemo/Include/InputGeom.h
@@ -31,11 +31,51 @@ struct ConvexVolume
 	int area;
 };
 
+struct BuildSettings
+{
+	// Cell size in world units
+	float cellSize;
+	// Cell height in world units
+	float cellHeight;
+	// Agent height in world units
+	float agentHeight;
+	// Agent radius in world units
+	float agentRadius;
+	// Agent max climb in world units
+	float agentMaxClimb;
+	// Agent max slope in degrees
+	float agentMaxSlope;
+	// Region minimum size in voxels.
+	// regionMinSize = sqrt(regionMinArea)
+	float regionMinSize;
+	// Region merge size in voxels.
+	// regionMergeSize = sqrt(regionMergeArea)
+	float regionMergeSize;
+	// Edge max length in world units
+	float edgeMaxLen;
+	// Edge max error in voxels
+	float edgeMaxError;
+	float vertsPerPoly;
+	// Detail sample distance in voxels
+	float detailSampleDist;
+	// Detail sample max error in voxel heights.
+	float detailSampleMaxError;
+	// Partition type, see SamplePartitionType
+	int partitionType;
+	// Bounds of the area to mesh
+	float navMeshBMin[3];
+	float navMeshBMax[3];
+	// Size of the tiles in voxels
+	float tileSize;
+};
+
 class InputGeom
 {
 	rcChunkyTriMesh* m_chunkyMesh;
 	rcMeshLoaderObj* m_mesh;
 	float m_meshBMin[3], m_meshBMax[3];
+	BuildSettings m_buildSettings;
+	bool m_hasBuildSettings;
 	
 	/// @name Off-Mesh connections.
 	///@{
@@ -56,20 +96,24 @@ class InputGeom
 	int m_volumeCount;
 	///@}
 	
+	bool loadMesh(class rcContext* ctx, const std::string& filepath);
+	bool loadGeomSet(class rcContext* ctx, const std::string& filepath);
 public:
 	InputGeom();
 	~InputGeom();
 	
-	bool loadMesh(class rcContext* ctx, const char* filepath);
 	
-	bool load(class rcContext* ctx, const char* filepath);
-	bool save(const char* filepath);
+	bool load(class rcContext* ctx, const std::string& filepath);
+	bool saveGeomSet(const BuildSettings* settings);
 	
 	/// Method to return static mesh data.
-	inline const rcMeshLoaderObj* getMesh() const { return m_mesh; }
-	inline const float* getMeshBoundsMin() const { return m_meshBMin; }
-	inline const float* getMeshBoundsMax() const { return m_meshBMax; }
-	inline const rcChunkyTriMesh* getChunkyMesh() const { return m_chunkyMesh; }
+	const rcMeshLoaderObj* getMesh() const { return m_mesh; }
+	const float* getMeshBoundsMin() const { return m_meshBMin; }
+	const float* getMeshBoundsMax() const { return m_meshBMax; }
+	const float* getNavMeshBoundsMin() const { return m_hasBuildSettings ? m_buildSettings.navMeshBMin : m_meshBMin; }
+	const float* getNavMeshBoundsMax() const { return m_hasBuildSettings ? m_buildSettings.navMeshBMax : m_meshBMax; }
+	const rcChunkyTriMesh* getChunkyMesh() const { return m_chunkyMesh; }
+	const BuildSettings* getBuildSettings() const { return m_hasBuildSettings ? &m_buildSettings : 0; }
 	bool raycastMesh(float* src, float* dst, float& tmin);
 
 	/// @name Off-Mesh connections.

--- a/RecastDemo/Include/MeshLoaderObj.h
+++ b/RecastDemo/Include/MeshLoaderObj.h
@@ -19,27 +19,29 @@
 #ifndef MESHLOADER_OBJ
 #define MESHLOADER_OBJ
 
+#include <string>
+
 class rcMeshLoaderObj
 {
 public:
 	rcMeshLoaderObj();
 	~rcMeshLoaderObj();
 	
-	bool load(const char* fileName);
+	bool load(const std::string& fileName);
 
-	inline const float* getVerts() const { return m_verts; }
-	inline const float* getNormals() const { return m_normals; }
-	inline const int* getTris() const { return m_tris; }
-	inline int getVertCount() const { return m_vertCount; }
-	inline int getTriCount() const { return m_triCount; }
-	inline const char* getFileName() const { return m_filename; }
+	const float* getVerts() const { return m_verts; }
+	const float* getNormals() const { return m_normals; }
+	const int* getTris() const { return m_tris; }
+	int getVertCount() const { return m_vertCount; }
+	int getTriCount() const { return m_triCount; }
+	const std::string& getFileName() const { return m_filename; }
 
 private:
 	
 	void addVertex(float x, float y, float z, int& cap);
 	void addTriangle(int a, int b, int c, int& cap);
 	
-	char m_filename[260];
+	std::string m_filename;
 	float m_scale;	
 	float* m_verts;
 	int* m_tris;

--- a/RecastDemo/Include/Sample.h
+++ b/RecastDemo/Include/Sample.h
@@ -141,6 +141,7 @@ public:
 	virtual void handleMeshChanged(class InputGeom* geom);
 	virtual bool handleBuild();
 	virtual void handleUpdate(const float dt);
+	virtual void collectSettings(struct BuildSettings& settings);
 
 	virtual class InputGeom* getInputGeom() { return m_geom; }
 	virtual class dtNavMesh* getNavMesh() { return m_navMesh; }
@@ -149,11 +150,9 @@ public:
 	virtual float getAgentRadius() { return m_agentRadius; }
 	virtual float getAgentHeight() { return m_agentHeight; }
 	virtual float getAgentClimb() { return m_agentMaxClimb; }
-	virtual const float* getBoundsMin();
-	virtual const float* getBoundsMax();
 	
-	inline unsigned char getNavMeshDrawFlags() const { return m_navMeshDrawFlags; }
-	inline void setNavMeshDrawFlags(unsigned char flags) { m_navMeshDrawFlags = flags; }
+	unsigned char getNavMeshDrawFlags() const { return m_navMeshDrawFlags; }
+	void setNavMeshDrawFlags(unsigned char flags) { m_navMeshDrawFlags = flags; }
 
 	void updateToolStates(const float dt);
 	void initToolStates(Sample* sample);

--- a/RecastDemo/Include/Sample_TileMesh.h
+++ b/RecastDemo/Include/Sample_TileMesh.h
@@ -69,8 +69,8 @@ protected:
 	float m_tileSize;
 	
 	unsigned int m_tileCol;
-	float m_tileBmin[3];
-	float m_tileBmax[3];
+	float m_lastBuiltTileBmin[3];
+	float m_lastBuiltTileBmax[3];
 	float m_tileBuildTime;
 	float m_tileMemUsage;
 	int m_tileTriCount;
@@ -93,6 +93,7 @@ public:
 	virtual void handleRenderOverlay(double* proj, double* model, int* view);
 	virtual void handleMeshChanged(class InputGeom* geom);
 	virtual bool handleBuild();
+	virtual void collectSettings(struct BuildSettings& settings);
 	
 	void getTilePos(const float* pos, int& tx, int& ty);
 	

--- a/RecastDemo/Include/TestCase.h
+++ b/RecastDemo/Include/TestCase.h
@@ -19,6 +19,7 @@
 #ifndef TESTCASE_H
 #define TESTCASE_H
 
+#include <string>
 #include "DetourNavMesh.h"
 
 class TestCase
@@ -60,8 +61,8 @@ class TestCase
 		Test* next;
 	};
 
-	char m_sampleName[256];
-	char m_geomFileName[256];
+	std::string m_sampleName;
+	std::string m_geomFileName;
 	Test* m_tests;
 	
 	void resetTimes();
@@ -70,10 +71,10 @@ public:
 	TestCase();
 	~TestCase();
 
-	bool load(const char* filePath);
+	bool load(const std::string& filePath);
 	
-	inline const char* getSampleName() const { return m_sampleName; }
-	inline const char* getGeomFileName() const { return m_geomFileName; }
+	const std::string& getSampleName() const { return m_sampleName; }
+	const std::string& getGeomFileName() const { return m_geomFileName; }
 	
 	void doTests(class dtNavMesh* navmesh, class dtNavMeshQuery* navquery);
 	

--- a/RecastDemo/Source/Filelist.cpp
+++ b/RecastDemo/Source/Filelist.cpp
@@ -29,10 +29,8 @@
 using std::vector;
 using std::string;
 
-void scanDirectory(string path, string ext, vector<string>& filelist)
+void scanDirectoryAppend(const string& path, const string& ext, vector<string>& filelist)
 {
-	filelist.clear();
-	
 #ifdef WIN32
 	string pathWithExt = path + "/*" + ext;
 	
@@ -70,4 +68,10 @@ void scanDirectory(string path, string ext, vector<string>& filelist)
 	
 	// Sort the list of files alphabetically.
 	std::sort(filelist.begin(), filelist.end());
+}
+
+void scanDirectory(const string& path, const string& ext, vector<string>& filelist)
+{
+	filelist.clear();
+	scanDirectoryAppend(path, ext, filelist);
 }

--- a/RecastDemo/Source/InputGeom.cpp
+++ b/RecastDemo/Source/InputGeom.cpp
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <ctype.h>
 #include <string.h>
+#include <algorithm>
 #include "Recast.h"
 #include "InputGeom.h"
 #include "ChunkyTriMesh.h"
@@ -107,6 +108,7 @@ static char* parseRow(char* buf, char* bufEnd, char* row, int len)
 InputGeom::InputGeom() :
 	m_chunkyMesh(0),
 	m_mesh(0),
+	m_hasBuildSettings(false),
 	m_offMeshConCount(0),
 	m_volumeCount(0)
 {
@@ -118,7 +120,7 @@ InputGeom::~InputGeom()
 	delete m_mesh;
 }
 		
-bool InputGeom::loadMesh(rcContext* ctx, const char* filepath)
+bool InputGeom::loadMesh(rcContext* ctx, const std::string& filepath)
 {
 	if (m_mesh)
 	{
@@ -138,7 +140,7 @@ bool InputGeom::loadMesh(rcContext* ctx, const char* filepath)
 	}
 	if (!m_mesh->load(filepath))
 	{
-		ctx->log(RC_LOG_ERROR, "buildTiledNavigation: Could not load '%s'", filepath);
+		ctx->log(RC_LOG_ERROR, "buildTiledNavigation: Could not load '%s'", filepath.c_str());
 		return false;
 	}
 
@@ -159,10 +161,10 @@ bool InputGeom::loadMesh(rcContext* ctx, const char* filepath)
 	return true;
 }
 
-bool InputGeom::load(rcContext* ctx, const char* filePath)
+bool InputGeom::loadGeomSet(rcContext* ctx, const std::string& filepath)
 {
 	char* buf = 0;
-	FILE* fp = fopen(filePath, "rb");
+	FILE* fp = fopen(filepath.c_str(), "rb");
 	if (!fp)
 		return false;
 	fseek(fp, 0, SEEK_END);
@@ -243,6 +245,33 @@ bool InputGeom::load(rcContext* ctx, const char* filePath)
 				}
 			}
 		}
+		else if (row[0] == 's')
+		{
+			// Settings
+			m_hasBuildSettings = true;
+			sscanf(row + 1, "%f %f %f %f %f %f %f %f %f %f %f %f %f %d %f %f %f %f %f %f %f",
+							&m_buildSettings.cellSize,
+							&m_buildSettings.cellHeight,
+							&m_buildSettings.agentHeight,
+							&m_buildSettings.agentRadius,
+							&m_buildSettings.agentMaxClimb,
+							&m_buildSettings.agentMaxSlope,
+							&m_buildSettings.regionMinSize,
+							&m_buildSettings.regionMergeSize,
+							&m_buildSettings.edgeMaxLen,
+							&m_buildSettings.edgeMaxError,
+							&m_buildSettings.vertsPerPoly,
+							&m_buildSettings.detailSampleDist,
+							&m_buildSettings.detailSampleMaxError,
+							&m_buildSettings.partitionType,
+							&m_buildSettings.navMeshBMin[0],
+							&m_buildSettings.navMeshBMin[1],
+							&m_buildSettings.navMeshBMin[2],
+							&m_buildSettings.navMeshBMax[0],
+							&m_buildSettings.navMeshBMax[1],
+							&m_buildSettings.navMeshBMax[2],
+							&m_buildSettings.tileSize);
+		}
 	}
 	
 	delete [] buf;
@@ -250,15 +279,68 @@ bool InputGeom::load(rcContext* ctx, const char* filePath)
 	return true;
 }
 
-bool InputGeom::save(const char* filepath)
+bool InputGeom::load(rcContext* ctx, const std::string& filepath)
+{
+	size_t extensionPos = filepath.find_last_of('.');
+	if (extensionPos == std::string::npos)
+		return false;
+
+	std::string extension = filepath.substr(extensionPos);
+	std::transform(extension.begin(), extension.end(), extension.begin(), tolower);
+
+	if (extension == ".gset")
+		return loadGeomSet(ctx, filepath);
+	if (extension == ".obj")
+		return loadMesh(ctx, filepath);
+
+	return false;
+}
+
+bool InputGeom::saveGeomSet(const BuildSettings* settings)
 {
 	if (!m_mesh) return false;
 	
-	FILE* fp = fopen(filepath, "w");
+	// Change extension
+	std::string filepath = m_mesh->getFileName();
+	size_t extPos = filepath.find_last_of('.');
+	if (extPos != std::string::npos)
+		filepath = filepath.substr(0, extPos);
+
+	filepath += ".gset";
+
+	FILE* fp = fopen(filepath.c_str(), "w");
 	if (!fp) return false;
 	
 	// Store mesh filename.
-	fprintf(fp, "f %s\n", m_mesh->getFileName());
+	fprintf(fp, "f %s\n", m_mesh->getFileName().c_str());
+
+	// Store settings if any
+	if (settings)
+	{
+		fprintf(fp,
+			"s %f %f %f %f %f %f %f %f %f %f %f %f %f %d %f %f %f %f %f %f %f\n",
+			settings->cellSize,
+			settings->cellHeight,
+			settings->agentHeight,
+			settings->agentRadius,
+			settings->agentMaxClimb,
+			settings->agentMaxSlope,
+			settings->regionMinSize,
+			settings->regionMergeSize,
+			settings->edgeMaxLen,
+			settings->edgeMaxError,
+			settings->vertsPerPoly,
+			settings->detailSampleDist,
+			settings->detailSampleMaxError,
+			settings->partitionType,
+			settings->navMeshBMin[0],
+			settings->navMeshBMin[1],
+			settings->navMeshBMin[2],
+			settings->navMeshBMax[0],
+			settings->navMeshBMax[1],
+			settings->navMeshBMax[2],
+			settings->tileSize);
+	}
 	
 	// Store off-mesh links.
 	for (int i = 0; i < m_offMeshConCount; ++i)

--- a/RecastDemo/Source/MeshLoaderObj.cpp
+++ b/RecastDemo/Source/MeshLoaderObj.cpp
@@ -19,7 +19,7 @@
 #include "MeshLoaderObj.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
+#include <cstring>
 #define _USE_MATH_DEFINES
 #include <math.h>
 
@@ -135,10 +135,10 @@ static int parseFace(char* row, int* data, int n, int vcnt)
 	return j;
 }
 
-bool rcMeshLoaderObj::load(const char* filename)
+bool rcMeshLoaderObj::load(const std::string& filename)
 {
 	char* buf = 0;
-	FILE* fp = fopen(filename, "rb");
+	FILE* fp = fopen(filename.c_str(), "rb");
 	if (!fp)
 		return false;
 	fseek(fp, 0, SEEK_END);
@@ -226,8 +226,6 @@ bool rcMeshLoaderObj::load(const char* filename)
 		}
 	}
 	
-	strncpy(m_filename, filename, sizeof(m_filename));
-	m_filename[sizeof(m_filename)-1] = '\0';
-	
+	m_filename = filename;
 	return true;
 }

--- a/RecastDemo/Source/Sample.cpp
+++ b/RecastDemo/Source/Sample.cpp
@@ -105,19 +105,45 @@ void Sample::handleRenderOverlay(double* /*proj*/, double* /*model*/, int* /*vie
 void Sample::handleMeshChanged(InputGeom* geom)
 {
 	m_geom = geom;
+
+	const BuildSettings* buildSettings = geom->getBuildSettings();
+	if (buildSettings)
+	{
+		m_cellSize = buildSettings->cellSize;
+		m_cellHeight = buildSettings->cellHeight;
+		m_agentHeight = buildSettings->agentHeight;
+		m_agentRadius = buildSettings->agentRadius;
+		m_agentMaxClimb = buildSettings->agentMaxClimb;
+		m_agentMaxSlope = buildSettings->agentMaxSlope;
+		m_regionMinSize = buildSettings->regionMinSize;
+		m_regionMergeSize = buildSettings->regionMergeSize;
+		m_edgeMaxLen = buildSettings->edgeMaxLen;
+		m_edgeMaxError = buildSettings->edgeMaxError;
+		m_vertsPerPoly = buildSettings->vertsPerPoly;
+		m_detailSampleDist = buildSettings->detailSampleDist;
+		m_detailSampleMaxError = buildSettings->detailSampleMaxError;
+		m_partitionType = buildSettings->partitionType;
+	}
 }
 
-const float* Sample::getBoundsMin()
+void Sample::collectSettings(BuildSettings& settings)
 {
-	if (!m_geom) return 0;
-	return m_geom->getMeshBoundsMin();
+	settings.cellSize = m_cellSize;
+	settings.cellHeight = m_cellHeight;
+	settings.agentHeight = m_agentHeight;
+	settings.agentRadius = m_agentRadius;
+	settings.agentMaxClimb = m_agentMaxClimb;
+	settings.agentMaxSlope = m_agentMaxSlope;
+	settings.regionMinSize = m_regionMinSize;
+	settings.regionMergeSize = m_regionMergeSize;
+	settings.edgeMaxLen = m_edgeMaxLen;
+	settings.edgeMaxError = m_edgeMaxError;
+	settings.vertsPerPoly = m_vertsPerPoly;
+	settings.detailSampleDist = m_detailSampleDist;
+	settings.detailSampleMaxError = m_detailSampleMaxError;
+	settings.partitionType = m_partitionType;
 }
 
-const float* Sample::getBoundsMax()
-{
-	if (!m_geom) return 0;
-	return m_geom->getMeshBoundsMax();
-}
 
 void Sample::resetCommonSettings()
 {
@@ -145,8 +171,8 @@ void Sample::handleCommonSettings()
 	
 	if (m_geom)
 	{
-		const float* bmin = m_geom->getMeshBoundsMin();
-		const float* bmax = m_geom->getMeshBoundsMax();
+		const float* bmin = m_geom->getNavMeshBoundsMin();
+		const float* bmax = m_geom->getNavMeshBoundsMax();
 		int gw = 0, gh = 0;
 		rcCalcGridSize(bmin, bmax, m_cellSize, &gw, &gh);
 		char text[64];

--- a/RecastDemo/Source/Sample_SoloMesh.cpp
+++ b/RecastDemo/Source/Sample_SoloMesh.cpp
@@ -235,8 +235,8 @@ void Sample_SoloMesh::handleRender()
 	glDepthMask(GL_FALSE);
 
 	// Draw bounds
-	const float* bmin = m_geom->getMeshBoundsMin();
-	const float* bmax = m_geom->getMeshBoundsMax();
+	const float* bmin = m_geom->getNavMeshBoundsMin();
+	const float* bmax = m_geom->getNavMeshBoundsMax();
 	duDebugDrawBoxWire(&dd, bmin[0],bmin[1],bmin[2], bmax[0],bmax[1],bmax[2], duRGBA(255,255,255,128), 1.0f);
 	dd.begin(DU_DRAW_POINTS, 5.0f);
 	dd.vertex(bmin[0],bmin[1],bmin[2],duRGBA(255,255,255,128));
@@ -362,8 +362,8 @@ bool Sample_SoloMesh::handleBuild()
 	
 	cleanup();
 	
-	const float* bmin = m_geom->getMeshBoundsMin();
-	const float* bmax = m_geom->getMeshBoundsMax();
+	const float* bmin = m_geom->getNavMeshBoundsMin();
+	const float* bmax = m_geom->getNavMeshBoundsMax();
 	const float* verts = m_geom->getMesh()->getVerts();
 	const int nverts = m_geom->getMesh()->getVertCount();
 	const int* tris = m_geom->getMesh()->getTris();

--- a/RecastDemo/Source/Sample_TempObstacles.cpp
+++ b/RecastDemo/Source/Sample_TempObstacles.cpp
@@ -866,8 +866,8 @@ void Sample_TempObstacles::handleSettings()
 	int gridSize = 1;
 	if (m_geom)
 	{
-		const float* bmin = m_geom->getMeshBoundsMin();
-		const float* bmax = m_geom->getMeshBoundsMax();
+		const float* bmin = m_geom->getNavMeshBoundsMin();
+		const float* bmax = m_geom->getNavMeshBoundsMax();
 		char text[64];
 		int gw = 0, gh = 0;
 		rcCalcGridSize(bmin, bmax, m_cellSize, &gw, &gh);
@@ -1059,8 +1059,8 @@ void Sample_TempObstacles::handleRender()
 	glDepthMask(GL_FALSE);
 	
 	// Draw bounds
-	const float* bmin = m_geom->getMeshBoundsMin();
-	const float* bmax = m_geom->getMeshBoundsMax();
+	const float* bmin = m_geom->getNavMeshBoundsMin();
+	const float* bmax = m_geom->getNavMeshBoundsMax();
 	duDebugDrawBoxWire(&dd, bmin[0],bmin[1],bmin[2], bmax[0],bmax[1],bmax[2], duRGBA(255,255,255,128), 1.0f);
 	
 	// Tiling grid.
@@ -1208,8 +1208,8 @@ bool Sample_TempObstacles::handleBuild()
 	m_tmproc->init(m_geom);
 	
 	// Init cache
-	const float* bmin = m_geom->getMeshBoundsMin();
-	const float* bmax = m_geom->getMeshBoundsMax();
+	const float* bmin = m_geom->getNavMeshBoundsMin();
+	const float* bmax = m_geom->getNavMeshBoundsMax();
 	int gw = 0, gh = 0;
 	rcCalcGridSize(bmin, bmax, m_cellSize, &gw, &gh);
 	const int ts = (int)m_tileSize;
@@ -1280,7 +1280,7 @@ bool Sample_TempObstacles::handleBuild()
 
 	dtNavMeshParams params;
 	memset(&params, 0, sizeof(params));
-	rcVcopy(params.orig, m_geom->getMeshBoundsMin());
+	rcVcopy(params.orig, bmin);
 	params.tileWidth = m_tileSize*m_cellSize;
 	params.tileHeight = m_tileSize*m_cellSize;
 	params.maxTiles = m_maxTiles;
@@ -1380,7 +1380,7 @@ void Sample_TempObstacles::getTilePos(const float* pos, int& tx, int& ty)
 {
 	if (!m_geom) return;
 	
-	const float* bmin = m_geom->getMeshBoundsMin();
+	const float* bmin = m_geom->getNavMeshBoundsMin();
 	
 	const float ts = m_tileSize*m_cellSize;
 	tx = (int)((pos[0] - bmin[0]) / ts);

--- a/RecastDemo/Source/TestCase.cpp
+++ b/RecastDemo/Source/TestCase.cpp
@@ -88,18 +88,18 @@ static char* parseRow(char* buf, char* bufEnd, char* row, int len)
 	return buf;
 }
 
-static void copyName(char* dst, const char* src)
+static void copyName(std::string& dst, const char* src)
 {
 	// Skip white spaces
 	while (*src && isspace(*src))
 		src++;
-	strcpy(dst, src);
+	dst = src;
 }
 
-bool TestCase::load(const char* filePath)
+bool TestCase::load(const std::string& filePath)
 {
 	char* buf = 0;
-	FILE* fp = fopen(filePath, "rb");
+	FILE* fp = fopen(filePath.c_str(), "rb");
 	if (!fp)
 		return false;
 	fseek(fp, 0, SEEK_END);


### PR DESCRIPTION
This adds the ability for geometry sets to store build settings that can
be automatically applied when they are loaded. This should allow sharing
of .gset files to demonstrate problems with certain settings on certain
files. It also allows people to diagnose problems more easily by being
able to dump their own triangle meshes and settings and load them in the
demo, with all of its visualization options. .gset files can be created
from the current mesh and settings by pressing the 9 key, which will
generate it in the same folder as the input mesh.

Also converts more of the demo to use STL.

The reason I introduced `navMeshBMin` and `navMeshBMax` is because it allows people
to use the demo to diagnose problems more easily. I (and I'm sure Mikko) have noticed a general
trend in visualizers for the meshes to be -- well poor, compared to RecastDemo (and so is mine!).
It should be easier for people to dump their problematic areas to a `.obj` and `.gset`, and include
the areas to mesh with their own settings now.

Additionally I have changed the `.gitignore` to ignore all files in `Meshes/`. I think most files will be there because we/people are testing on other meshes, not because we want to add them to the repo - if we really want to we can always do it with `git add -f`.