### PR TITLE
Add API to query polygons in batches

### DIFF
--- a/Detour/Source/DetourNavMeshQuery.cpp
+++ b/Detour/Source/DetourNavMeshQuery.cpp
@@ -697,14 +697,63 @@ dtStatus dtNavMeshQuery::getPolyHeight(dtPolyRef ref, const float* pos, float* h
 	return DT_FAILURE | DT_INVALID_PARAM;
 }
 
+class dtFindNearestPolyQuery : public dtPolyQuery
+{
+	const dtNavMeshQuery* m_query;
+	const float* m_center;
+	float m_nearestDistanceSqr;
+	dtPolyRef m_nearestRef;
+	float m_nearestPoint[3];
+
+public:
+	dtFindNearestPolyQuery(const dtNavMeshQuery* query, const float* center)
+		: m_query(query), m_center(center), m_nearestDistanceSqr(FLT_MAX), m_nearestRef(0), m_nearestPoint()
+	{
+	}
+
+	dtPolyRef nearestRef() const { return m_nearestRef; }
+	const float* nearestPoint() const { return m_nearestPoint; }
+
+	void process(const dtMeshTile* tile, dtPoly** polys, dtPolyRef* refs, int count)
+	{
+		for (int i = 0; i < count; ++i)
+		{
+			dtPolyRef ref = refs[i];
+			float closestPtPoly[3];
+			float diff[3];
+			bool posOverPoly = false;
+			float d;
+			m_query->closestPointOnPoly(ref, m_center, closestPtPoly, &posOverPoly);
+
+			// If a point is directly over a polygon and closer than
+			// climb height, favor that instead of straight line nearest point.
+			dtVsub(diff, m_center, closestPtPoly);
+			if (posOverPoly)
+			{
+				d = dtAbs(diff[1]) - tile->header->walkableClimb;
+				d = d > 0 ? d*d : 0;			
+			}
+			else
+			{
+				d = dtVlenSqr(diff);
+			}
+			
+			if (d < m_nearestDistanceSqr)
+			{
+				dtVcopy(m_nearestPoint, closestPtPoly);
+
+				m_nearestDistanceSqr = d;
+				m_nearestRef = ref;
+			}
+		}
+	}
+};
+
 /// @par 
 ///
 /// @note If the search box does not intersect any polygons the search will 
 /// return #DT_SUCCESS, but @p nearestRef will be zero. So if in doubt, check 
 /// @p nearestRef before using @p nearestPt.
-///
-/// @warning This function is not suitable for large area searches.  If the search
-/// extents overlaps more than MAX_SEARCH (128) polygons it may return an invalid result.
 ///
 dtStatus dtNavMeshQuery::findNearestPoly(const float* center, const float* extents,
 										 const dtQueryFilter* filter,
@@ -715,70 +764,29 @@ dtStatus dtNavMeshQuery::findNearestPoly(const float* center, const float* exten
 	if (!nearestRef)
 		return DT_FAILURE | DT_INVALID_PARAM;
 	
-	// Get nearby polygons from proximity grid.
-	const int MAX_SEARCH = 128;
-	dtPolyRef polys[MAX_SEARCH];
-	int polyCount = 0;
-	if (dtStatusFailed(queryPolygons(center, extents, filter, polys, &polyCount, MAX_SEARCH)))
-		return DT_FAILURE | DT_INVALID_PARAM;
-	
-	*nearestRef = 0;
+	dtFindNearestPolyQuery query(this, center);
 
-	if (polyCount == 0)
-		return DT_SUCCESS;
-	
-	// Find nearest polygon amongst the nearby polygons.
-	dtPolyRef nearest = 0;
-	float nearestPoint[3];
+	dtStatus status = queryPolygons(center, extents, filter, &query);
+	if (dtStatusFailed(status))
+		return status;
 
-	float nearestDistanceSqr = FLT_MAX;
-	for (int i = 0; i < polyCount; ++i)
-	{
-		dtPolyRef ref = polys[i];
-		float closestPtPoly[3];
-		float diff[3];
-		bool posOverPoly = false;
-		float d = 0;
-		closestPointOnPoly(ref, center, closestPtPoly, &posOverPoly);
-
-		// If a point is directly over a polygon and closer than
-		// climb height, favor that instead of straight line nearest point.
-		dtVsub(diff, center, closestPtPoly);
-		if (posOverPoly)
-		{
-			const dtMeshTile* tile = 0;
-			const dtPoly* poly = 0;
-			m_nav->getTileAndPolyByRefUnsafe(polys[i], &tile, &poly);
-			d = dtAbs(diff[1]) - tile->header->walkableClimb;
-			d = d > 0 ? d*d : 0;			
-		}
-		else
-		{
-			d = dtVlenSqr(diff);
-		}
-		
-		if (d < nearestDistanceSqr)
-		{
-			dtVcopy(nearestPoint, closestPtPoly);
-
-			nearestDistanceSqr = d;
-			nearest = ref;
-		}
-	}
-	
-	*nearestRef = nearest;
-
-	if (nearestPt)
-		dtVcopy(nearestPt, nearestPoint);
+	*nearestRef = query.nearestRef();
+	// Only override nearestPt if we actually found a poly so the nearest point
+	// is valid.
+	if (nearestPt && *nearestRef)
+		dtVcopy(nearestPt, query.nearestPoint());
 	
 	return DT_SUCCESS;
 }
 
-int dtNavMeshQuery::queryPolygonsInTile(const dtMeshTile* tile, const float* qmin, const float* qmax,
-										const dtQueryFilter* filter,
-										dtPolyRef* polys, const int maxPolys) const
+void dtNavMeshQuery::queryPolygonsInTile(const dtMeshTile* tile, const float* qmin, const float* qmax,
+										 const dtQueryFilter* filter, dtPolyQuery* query) const
 {
 	dtAssert(m_nav);
+	static const int batchSize = 32;
+	dtPolyRef polyRefs[batchSize];
+	dtPoly* polys[batchSize];
+	int n = 0;
 
 	if (tile->bvTree)
 	{
@@ -787,7 +795,7 @@ int dtNavMeshQuery::queryPolygonsInTile(const dtMeshTile* tile, const float* qmi
 		const float* tbmin = tile->header->bmin;
 		const float* tbmax = tile->header->bmax;
 		const float qfac = tile->header->bvQuantFactor;
-		
+
 		// Calculate quantized box
 		unsigned short bmin[3], bmax[3];
 		// dtClamp query box to world box.
@@ -804,25 +812,34 @@ int dtNavMeshQuery::queryPolygonsInTile(const dtMeshTile* tile, const float* qmi
 		bmax[0] = (unsigned short)(qfac * maxx + 1) | 1;
 		bmax[1] = (unsigned short)(qfac * maxy + 1) | 1;
 		bmax[2] = (unsigned short)(qfac * maxz + 1) | 1;
-		
+
 		// Traverse tree
 		const dtPolyRef base = m_nav->getPolyRefBase(tile);
-		int n = 0;
 		while (node < end)
 		{
 			const bool overlap = dtOverlapQuantBounds(bmin, bmax, node->bmin, node->bmax);
 			const bool isLeafNode = node->i >= 0;
-			
+
 			if (isLeafNode && overlap)
 			{
 				dtPolyRef ref = base | (dtPolyRef)node->i;
 				if (filter->passFilter(ref, tile, &tile->polys[node->i]))
 				{
-					if (n < maxPolys)
-						polys[n++] = ref;
+					polyRefs[n] = ref;
+					polys[n] = &tile->polys[node->i];
+
+					if (n == batchSize - 1)
+					{
+						query->process(tile, polys, polyRefs, batchSize);
+						n = 0;
+					}
+					else
+					{
+						n++;
+					}
 				}
 			}
-			
+
 			if (overlap || isLeafNode)
 				node++;
 			else
@@ -831,17 +848,14 @@ int dtNavMeshQuery::queryPolygonsInTile(const dtMeshTile* tile, const float* qmi
 				node += escapeIndex;
 			}
 		}
-		
-		return n;
 	}
 	else
 	{
 		float bmin[3], bmax[3];
-		int n = 0;
 		const dtPolyRef base = m_nav->getPolyRefBase(tile);
 		for (int i = 0; i < tile->header->polyCount; ++i)
 		{
-			const dtPoly* p = &tile->polys[i];
+			dtPoly* p = &tile->polys[i];
 			// Do not return off-mesh connection polygons.
 			if (p->getType() == DT_POLYTYPE_OFFMESH_CONNECTION)
 				continue;
@@ -859,15 +873,59 @@ int dtNavMeshQuery::queryPolygonsInTile(const dtMeshTile* tile, const float* qmi
 				dtVmin(bmin, v);
 				dtVmax(bmax, v);
 			}
-			if (dtOverlapBounds(qmin,qmax, bmin,bmax))
+			if (dtOverlapBounds(qmin, qmax, bmin, bmax))
 			{
-				if (n < maxPolys)
-					polys[n++] = ref;
+				polyRefs[n] = ref;
+				polys[n] = p;
+
+				if (n == batchSize - 1)
+				{
+					query->process(tile, polys, polyRefs, batchSize);
+					n = 0;
+				}
+				else
+				{
+					n++;
+				}
 			}
 		}
-		return n;
 	}
+
+	// Process the last polygons that didn't make a full batch.
+	if (n > 0)
+		query->process(tile, polys, polyRefs, n);
 }
+
+class dtCollectPolysQuery : public dtPolyQuery
+{
+	dtPolyRef* m_polys;
+	const int m_maxPolys;
+	int m_numCollected;
+	bool m_overflow;
+
+public:
+	dtCollectPolysQuery(dtPolyRef* polys, const int maxPolys)
+		: m_polys(polys), m_maxPolys(maxPolys), m_numCollected(0), m_overflow(false)
+	{
+	}
+
+	int numCollected() const { return m_numCollected; }
+	bool overflowed() const { return m_overflow; }
+
+	void process(const dtMeshTile* tile, dtPoly** polys, dtPolyRef* refs, int count)
+	{
+		int numLeft = m_maxPolys - m_numCollected;
+		int toCopy = count;
+		if (toCopy > numLeft)
+		{
+			m_overflow = true;
+			toCopy = numLeft;
+		}
+
+		memcpy(m_polys + m_numCollected, refs, (size_t)toCopy * sizeof(dtPolyRef));
+		m_numCollected += toCopy;
+	}
+};
 
 /// @par 
 ///
@@ -882,8 +940,34 @@ dtStatus dtNavMeshQuery::queryPolygons(const float* center, const float* extents
 									   const dtQueryFilter* filter,
 									   dtPolyRef* polys, int* polyCount, const int maxPolys) const
 {
+	if (!polys || !polyCount || maxPolys < 0)
+		return DT_FAILURE | DT_INVALID_PARAM;
+
+	dtCollectPolysQuery collector(polys, maxPolys);
+
+	dtStatus status = queryPolygons(center, extents, filter, &collector);
+	if (dtStatusFailed(status))
+		return status;
+
+	*polyCount = collector.numCollected();
+	return collector.overflowed() ? DT_SUCCESS | DT_BUFFER_TOO_SMALL : DT_SUCCESS;
+}
+
+/// @par 
+///
+/// The query will be invoked with batches of polygons. Polygons passed
+/// to the query have bounding boxes that overlap with the center and extents
+/// passed to this function. The dtPolyQuery::process function is invoked multiple
+/// times until all overlapping polygons have been processed.
+///
+dtStatus dtNavMeshQuery::queryPolygons(const float* center, const float* extents,
+									   const dtQueryFilter* filter, dtPolyQuery* query) const
+{
 	dtAssert(m_nav);
-	
+
+	if (!center || !extents || !filter || !query)
+		return DT_FAILURE | DT_INVALID_PARAM;
+
 	float bmin[3], bmax[3];
 	dtVsub(bmin, center, extents);
 	dtVadd(bmax, center, extents);
@@ -896,7 +980,6 @@ dtStatus dtNavMeshQuery::queryPolygons(const float* center, const float* extents
 	static const int MAX_NEIS = 32;
 	const dtMeshTile* neis[MAX_NEIS];
 	
-	int n = 0;
 	for (int y = miny; y <= maxy; ++y)
 	{
 		for (int x = minx; x <= maxx; ++x)
@@ -904,16 +987,10 @@ dtStatus dtNavMeshQuery::queryPolygons(const float* center, const float* extents
 			const int nneis = m_nav->getTilesAt(x,y,neis,MAX_NEIS);
 			for (int j = 0; j < nneis; ++j)
 			{
-				n += queryPolygonsInTile(neis[j], bmin, bmax, filter, polys+n, maxPolys-n);
-				if (n >= maxPolys)
-				{
-					*polyCount = n;
-					return DT_SUCCESS | DT_BUFFER_TOO_SMALL;
-				}
+				queryPolygonsInTile(neis[j], bmin, bmax, filter, query);
 			}
 		}
 	}
-	*polyCount = n;
 	
 	return DT_SUCCESS;
 }


### PR DESCRIPTION
This adds a version of queryPolygon that takes an interface which is
passed batches of polygons in the search area. This new API is then used
from the old queryPolygons to collect polygons, and from findNearestRef
to find the nearest poly in an arbitrarily sized area. Previously
findNearestPoly had an arbitrary poly limit of 128 which could cause it
to return potentially wrong results.

Fix #107

I was concerned about the impact of this since it adds some virtual overhead
and additional copying to `queryPolygons`. I've added some benchmarks below.
At least on my CPU the overhead is not extremely high, though it is still around 10%
at large extents. The comments at the top of `DetourNavMeshQuery.h` say that
virtual dispatch is expensive on certain platforms, so the performance regression
may be worse on those platforms. We could have two versions of `queryPolygonsInTile`,
but of course I would prefer to keep it as it is now. Thoughts?

### Benchmarks for `findNearestPoly`
I varied extents up to 14, 28, 14. Tests at higher extents weren't meaningful due to
the old version reaching the 128 polygon limit and thus potentially returning wrong results.
#### New
Extents | Number of queries | Total time | Average time per query
--- | --- | --- | ---
(2, 4, 2) | 2710 | 1.49 ms | 0.550 microseconds
(4, 8, 4) | 2710 | 3.38 ms | 1.249 microseconds
(6, 12, 6) | 2710 | 6.08 ms | 2.245 microseconds
(8, 16, 8) | 2710 | 9.48 ms | 3.498 microseconds
(10, 20, 10) | 2710 | 13.48 ms | 4.973 microseconds
(12, 24, 12) | 2710 | 16.91 ms | 6.239 microseconds
(14, 28, 14) | 2710 | 20.64 ms | 7.615 microseconds

#### Old
Extents | Number of queries | Total time | Average time per query
--- | --- | --- | ---
(2, 4, 2) | 2710 | 1.46 ms | 0.538 microseconds
(4, 8, 4) | 2710 | 3.28 ms | 1.209 microseconds
(6, 12, 6) | 2710 | 6.06 ms | 2.235 microseconds
(8, 16, 8) | 2710 | 9.20 ms | 3.396 microseconds
(10, 20, 10) | 2710 | 12.97 ms | 4.785 microseconds
(12, 24, 12) | 2710 | 16.50 ms | 6.089 microseconds
(14, 28, 14) | 2710 | 20.14 ms | 7.430 microseconds

Almost no overhead in the new version.

### Benchmarks for `queryPolygons`
#### New
Extents | Number of queries | Total time | Average time per query
--- | --- | --- | ---
(2, 4, 2) | 2710  | 0.45 ms | 0.165 microseconds
(4, 8, 4) | 2710  | 0.79 ms | 0.292 microseconds
(6, 12, 6) | 2710  | 1.15 ms | 0.425 microseconds
(8, 16, 8) | 2710  | 1.60 ms | 0.590 microseconds
(10, 20, 10) | 2710 | 2.07 ms | 0.762 microseconds
(12, 24, 12) | 2710 | 2.33 ms | 0.861 microseconds
(14, 28, 14) | 2710 | 2.67 ms | 0.986 microseconds
(16, 32, 16) | 2710 | 3.15 ms | 1.163 microseconds
(18, 36, 18) | 2710 | 3.61 ms | 1.332 microseconds
(20, 40, 20) | 2710 | 4.04 ms | 1.492 microseconds
(22, 44, 22) | 2710 | 6.36 ms | 2.347 microseconds
(24, 48, 24) | 2710 | 5.09 ms | 1.877 microseconds
(26, 52, 26) | 2710 | 5.49 ms | 2.026 microseconds
(28, 56, 28) | 2710 | 5.92 ms | 2.183 microseconds
(30, 60, 30) | 2710 | 6.44 ms | 2.376 microseconds
(32, 64, 32) | 2710 | 6.99 ms | 2.578 microseconds
(34, 68, 34) | 2710 | 7.22 ms | 2.666 microseconds
(36, 72, 36) | 2710 | 7.70 ms | 2.842 microseconds
(38, 76, 38) | 2710 | 8.19 ms | 3.022 microseconds
(40, 80, 40) | 2710 | 8.59 ms | 3.170 microseconds
(42, 84, 42) | 2710 | 9.14 ms | 3.372 microseconds
(44, 88, 44) | 2710 | 9.44 ms | 3.483 microseconds
(46, 92, 46) | 2710 | 9.90 ms | 3.652 microseconds
(48, 96, 48) | 2710 | 10.08 ms | 3.718 microseconds
(50, 100, 50) | 2710 | 10.72 ms | 3.955 microseconds

### Old
Extents | Number of queries | Total time | Average time per query
--- | --- | --- | ---
(2, 4, 2) | 2710 | 0.38 ms | 0.141 microseconds
(4, 8, 4) | 2710 |  0.64 ms | 0.236 microseconds
(6, 12, 6) | 2710 | 0.97 ms | 0.358 microseconds
(8, 16, 8) | 2710 | 1.34 ms | 0.496 microseconds
(10, 20, 10) | 2710 | 1.71 ms | 0.632 microseconds
(12, 24, 12) | 2710 | 1.95 ms | 0.721 microseconds
(14, 28, 14) | 2710 | 2.40 ms | 0.886 microseconds
(16, 32, 16) | 2710 | 2.65 ms | 0.977 microseconds
(18, 36, 18) | 2710 | 3.04 ms | 1.120 microseconds
(20, 40, 20) | 2710 | 3.51 ms | 1.296 microseconds
(22, 44, 22) | 2710 | 3.87 ms | 1.427 microseconds
(24, 48, 24) | 2710 | 4.39 ms | 1.620 microseconds
(26, 52, 26) | 2710 | 4.65 ms | 1.717 microseconds
(28, 56, 28) | 2710 | 5.05 ms | 1.865 microseconds
(30, 60, 30) | 2710 | 5.59 ms | 2.063 microseconds
(32, 64, 32) | 2710 | 5.92 ms | 2.185 microseconds
(34, 68, 34) | 2710 | 6.25 ms | 2.305 microseconds
(36, 72, 36) | 2710 | 6.73 ms | 2.485 microseconds
(38, 76, 38) | 2710 | 7.13 ms | 2.631 microseconds
(40, 80, 40) | 2710 | 7.54 ms | 2.783 microseconds
(42, 84, 42) | 2710 | 7.86 ms | 2.900 microseconds
(44, 88, 44) | 2710 | 8.32 ms | 3.068 microseconds
(46, 92, 46) | 2710 | 8.68 ms | 3.201 microseconds
(48, 96, 48) | 2710 | 8.88 ms | 3.276 microseconds
(50, 100, 50) | 2710 | 9.47 ms | 3.495 microseconds