### PR TITLE
Fix warnings and increase demo text pool size

### DIFF
--- a/Detour/Source/DetourNavMeshQuery.cpp
+++ b/Detour/Source/DetourNavMeshQuery.cpp
@@ -716,6 +716,8 @@ public:
 
 	void process(const dtMeshTile* tile, dtPoly** polys, dtPolyRef* refs, int count)
 	{
+		dtIgnoreUnused(polys);
+
 		for (int i = 0; i < count; ++i)
 		{
 			dtPolyRef ref = refs[i];
@@ -914,6 +916,9 @@ public:
 
 	void process(const dtMeshTile* tile, dtPoly** polys, dtPolyRef* refs, int count)
 	{
+		dtIgnoreUnused(tile);
+		dtIgnoreUnused(polys);
+
 		int numLeft = m_maxPolys - m_numCollected;
 		int toCopy = count;
 		if (toCopy > numLeft)

--- a/RecastDemo/Source/imgui.cpp
+++ b/RecastDemo/Source/imgui.cpp
@@ -28,7 +28,7 @@
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-static const unsigned TEXT_POOL_SIZE = 8000;
+static const unsigned TEXT_POOL_SIZE = 50000;
 static char g_textPool[TEXT_POOL_SIZE];
 static unsigned g_textPoolSize = 0;
 static const char* allocText(const char* text)


### PR DESCRIPTION
Fix three warnings added in fc5df2c, and increase the text pool size in
the demo. This would frequently be overflowed, even just by building
with the default settings and expanding the log.