### PR TITLE
Fix Win64 when populating input file list

### DIFF
--- a/RecastDemo/Source/Filelist.cpp
+++ b/RecastDemo/Source/Filelist.cpp
@@ -35,7 +35,7 @@ void scanDirectoryAppend(const string& path, const string& ext, vector<string>& 
 	string pathWithExt = path + "/*" + ext;
 	
 	_finddata_t dir;
-	long fh = _findfirst(pathWithExt.c_str(), &dir);
+	intptr_t fh = _findfirst(pathWithExt.c_str(), &dir);
 	if (fh == -1L)
 	{
 		return;


### PR DESCRIPTION
As identified by @b-desconocido, `_findfirst` has a return type of `intptr_t`;
this was previously being truncated to long, resulting in a crash on 64 bit Windows.

Fix #185