### PR TITLE
Miscellaneous warning fixes, part 3

### DIFF
--- a/Detour/Source/DetourNavMesh.cpp
+++ b/Detour/Source/DetourNavMesh.cpp
@@ -651,9 +651,9 @@ void dtNavMesh::closestPointOnPoly(dtPolyRef ref, const float* pos, float* close
 	if (!dtDistancePtPolyEdgesSqr(pos, verts, nv, edged, edget))
 	{
 		// Point is outside the polygon, dtClamp to nearest edge.
-		float dmin = FLT_MAX;
-		int imin = -1;
-		for (int i = 0; i < nv; ++i)
+		float dmin = edged[0];
+		int imin = 0;
+		for (int i = 1; i < nv; ++i)
 		{
 			if (edged[i] < dmin)
 			{

--- a/Detour/Source/DetourNavMeshQuery.cpp
+++ b/Detour/Source/DetourNavMeshQuery.cpp
@@ -542,9 +542,9 @@ dtStatus dtNavMeshQuery::closestPointOnPoly(dtPolyRef ref, const float* pos, flo
 	if (!dtDistancePtPolyEdgesSqr(pos, verts, nv, edged, edget))
 	{
 		// Point is outside the polygon, dtClamp to nearest edge.
-		float dmin = FLT_MAX;
-		int imin = -1;
-		for (int i = 0; i < nv; ++i)
+		float dmin = edged[0];
+		int imin = 0;
+		for (int i = 1; i < nv; ++i)
 		{
 			if (edged[i] < dmin)
 			{
@@ -628,9 +628,9 @@ dtStatus dtNavMeshQuery::closestPointOnPolyBoundary(dtPolyRef ref, const float* 
 	else
 	{
 		// Point is outside the polygon, dtClamp to nearest edge.
-		float dmin = FLT_MAX;
-		int imin = -1;
-		for (int i = 0; i < nv; ++i)
+		float dmin = edged[0];
+		int imin = 0;
+		for (int i = 1; i < nv; ++i)
 		{
 			if (edged[i] < dmin)
 			{

--- a/DetourTileCache/Source/DetourTileCache.cpp
+++ b/DetourTileCache/Source/DetourTileCache.cpp
@@ -77,6 +77,7 @@ dtTileCache::dtTileCache() :
 	m_nupdate(0)
 {
 	memset(&m_params, 0, sizeof(m_params));
+	memset(m_reqs, 0, sizeof(ObstacleRequest) * MAX_REQUESTS);
 }
 	
 dtTileCache::~dtTileCache()

--- a/Recast/Source/RecastMeshDetail.cpp
+++ b/Recast/Source/RecastMeshDetail.cpp
@@ -647,11 +647,10 @@ static bool buildPolyDetail(rcContext* ctx, const float* in, const int nin,
 	int hull[MAX_VERTS];
 	int nhull = 0;
 	
-	nverts = 0;
+	nverts = nin;
 	
 	for (int i = 0; i < nin; ++i)
 		rcVcopy(&verts[i*3], &in[i*3]);
-	nverts = nin;
 	
 	edges.resize(0);
 	tris.resize(0);

--- a/Recast/Source/RecastRegion.cpp
+++ b/Recast/Source/RecastRegion.cpp
@@ -1575,12 +1575,6 @@ bool rcBuildRegions(rcContext* ctx, rcCompactHeightfield& chf,
 		// Make sure border will not overflow.
 		const int bw = rcMin(w, borderSize);
 		const int bh = rcMin(h, borderSize);
-
-		if (regionId > 0xFFFB)
-		{
-			ctx->log(RC_LOG_ERROR, "rcBuildRegions: Region ID overflow");
-			return false;
-		}
 		
 		// Paint regions
 		paintRectRegion(0, bw, 0, h, regionId|RC_BORDER_REG, chf, srcReg); regionId++;

--- a/RecastDemo/Contrib/stb_truetype.h
+++ b/RecastDemo/Contrib/stb_truetype.h
@@ -2064,7 +2064,7 @@ static void stbtt__fill_active_edges_new(float *scanline, float *scanline_fill, 
 }
 
 // directly AA rasterize edges w/o supersampling
-static void stbtt__rasterize_sorted_edges(stbtt__bitmap *result, stbtt__edge *e, int n, int vsubsample, int off_x, int off_y, void *userdata)
+static void stbtt__rasterize_sorted_edges(stbtt__bitmap *result, stbtt__edge *e, int n, int /*vsubsample*/, int off_x, int off_y, void *userdata)
 {
    stbtt__hheap hh = { 0, 0, 0 };
    stbtt__active_edge *active = NULL;

--- a/RecastDemo/Contrib/stb_truetype.h
+++ b/RecastDemo/Contrib/stb_truetype.h
@@ -2430,7 +2430,10 @@ STBTT_DEF unsigned char *stbtt_GetGlyphBitmapSubpixel(const stbtt_fontinfo *info
 
    if (scale_x == 0) scale_x = scale_y;
    if (scale_y == 0) {
-      if (scale_x == 0) return NULL;
+      if (scale_x == 0) {
+         STBTT_free(vertices, info->userdata);
+         return NULL;
+	  }
       scale_y = scale_x;
    }
 

--- a/RecastDemo/Source/InputGeom.cpp
+++ b/RecastDemo/Source/InputGeom.cpp
@@ -166,10 +166,26 @@ bool InputGeom::loadGeomSet(rcContext* ctx, const std::string& filepath)
 	char* buf = 0;
 	FILE* fp = fopen(filepath.c_str(), "rb");
 	if (!fp)
+	{
 		return false;
-	fseek(fp, 0, SEEK_END);
-	int bufSize = ftell(fp);
-	fseek(fp, 0, SEEK_SET);
+	}
+	if (fseek(fp, 0, SEEK_END) != 0)
+	{
+		fclose(fp);
+		return false;
+	}
+
+	long bufSize = ftell(fp);
+	if (bufSize < 0)
+	{
+		fclose(fp);
+		return false;
+	}
+	if (fseek(fp, 0, SEEK_SET) != 0)
+	{
+		fclose(fp);
+		return false;
+	}
 	buf = new char[bufSize];
 	if (!buf)
 	{

--- a/RecastDemo/Source/MeshLoaderObj.cpp
+++ b/RecastDemo/Source/MeshLoaderObj.cpp
@@ -141,9 +141,22 @@ bool rcMeshLoaderObj::load(const std::string& filename)
 	FILE* fp = fopen(filename.c_str(), "rb");
 	if (!fp)
 		return false;
-	fseek(fp, 0, SEEK_END);
-	int bufSize = ftell(fp);
-	fseek(fp, 0, SEEK_SET);
+	if (fseek(fp, 0, SEEK_END) != 0)
+	{
+		fclose(fp);
+		return false;
+	}
+	long bufSize = ftell(fp);
+	if (bufSize < 0)
+	{
+		fclose(fp);
+		return false;
+	}
+	if (fseek(fp, 0, SEEK_SET) != 0)
+	{
+		fclose(fp);
+		return false;
+	}
 	buf = new char[bufSize];
 	if (!buf)
 	{

--- a/RecastDemo/Source/SampleInterfaces.cpp
+++ b/RecastDemo/Source/SampleInterfaces.cpp
@@ -20,6 +20,8 @@ BuildContext::BuildContext() :
 	m_messageCount(0),
 	m_textPoolSize(0)
 {
+	memset(m_messages, 0, sizeof(char*) * MAX_MESSAGES);
+
 	resetTimers();
 }
 

--- a/RecastDemo/Source/Sample_TempObstacles.cpp
+++ b/RecastDemo/Source/Sample_TempObstacles.cpp
@@ -726,7 +726,7 @@ public:
 	
 	virtual void handleRender()
 	{
-		if (m_hitPosSet)
+		if (m_hitPosSet && m_sample)
 		{
 			const float s = m_sample->getAgentRadius();
 			glColor4ub(0,0,0,128);
@@ -740,14 +740,10 @@ public:
 			glVertex3f(m_hitPos[0],m_hitPos[1]+0.1f,m_hitPos[2]+s);
 			glEnd();
 			glLineWidth(1.0f);
-			
-			if (m_sample)
-			{
-				int tx=0, ty=0;
-				m_sample->getTilePos(m_hitPos, tx, ty);
-				m_sample->renderCachedTile(tx,ty,m_drawType);
-			}
 
+			int tx=0, ty=0;
+			m_sample->getTilePos(m_hitPos, tx, ty);
+			m_sample->renderCachedTile(tx,ty,m_drawType);
 		}
 	}
 	

--- a/RecastDemo/Source/Sample_TileMesh.cpp
+++ b/RecastDemo/Source/Sample_TileMesh.cpp
@@ -324,7 +324,10 @@ dtNavMesh* Sample_TileMesh::loadAll(const char* path)
 		NavMeshTileHeader tileHeader;
 		readLen = fread(&tileHeader, sizeof(tileHeader), 1, fp);
 		if (readLen != 1)
+		{
+			fclose(fp);
 			return 0;
+		}
 
 		if (!tileHeader.tileRef || !tileHeader.dataSize)
 			break;
@@ -334,7 +337,10 @@ dtNavMesh* Sample_TileMesh::loadAll(const char* path)
 		memset(data, 0, tileHeader.dataSize);
 		readLen = fread(data, tileHeader.dataSize, 1, fp);
 		if (readLen != 1)
+		{
+			fclose(fp);
 			return 0;
+		}
 
 		mesh->addTile(data, tileHeader.dataSize, DT_TILE_FREE_DATA, tileHeader.tileRef, 0);
 	}

--- a/RecastDemo/Source/TestCase.cpp
+++ b/RecastDemo/Source/TestCase.cpp
@@ -102,9 +102,22 @@ bool TestCase::load(const std::string& filePath)
 	FILE* fp = fopen(filePath.c_str(), "rb");
 	if (!fp)
 		return false;
-	fseek(fp, 0, SEEK_END);
-	int bufSize = ftell(fp);
-	fseek(fp, 0, SEEK_SET);
+	if (fseek(fp, 0, SEEK_END) != 0)
+	{
+		fclose(fp);
+		return false;
+	}
+	long bufSize = ftell(fp);
+	if (bufSize < 0)
+	{
+		fclose(fp);
+		return false;
+	}
+	if (fseek(fp, 0, SEEK_SET) != 0)
+	{
+		fclose(fp);
+		return false;
+	}
 	buf = new char[bufSize];
 	if (!buf)
 	{

--- a/RecastDemo/Source/imguiRenderGL.cpp
+++ b/RecastDemo/Source/imguiRenderGL.cpp
@@ -247,9 +247,22 @@ bool imguiRenderGLInit(const char* fontpath)
 	// Load font.
 	FILE* fp = fopen(fontpath, "rb");
 	if (!fp) return false;
-	fseek(fp, 0, SEEK_END);
-	size_t size = ftell(fp);
-	fseek(fp, 0, SEEK_SET);
+	if (fseek(fp, 0, SEEK_END) != 0)
+	{
+		fclose(fp);
+		return false;
+	}
+	long size = ftell(fp);
+	if (size < 0)
+	{
+		fclose(fp);
+		return false;
+	}
+	if (fseek(fp, 0, SEEK_SET) != 0)
+	{
+		fclose(fp);
+		return false;
+	}
 	
 	unsigned char* ttfBuffer = (unsigned char*)malloc(size); 
 	if (!ttfBuffer)
@@ -260,7 +273,7 @@ bool imguiRenderGLInit(const char* fontpath)
 	
 	size_t readLen = fread(ttfBuffer, 1, size, fp);
 	fclose(fp);
-	if (readLen != size)
+	if (readLen != static_cast<size_t>(size))
 	{
 		free(ttfBuffer);
 		return false;


### PR DESCRIPTION
Yet more warning fixes, for a smattering of issues found using either Coverity Scan, clang's scan-build or ReSharper C++. Each fix is in its own commit so the best way to see what's fixed is to read the individual commit messages.