### PR TITLE
Added Constructor and Destructor to rcHeightfield

### DIFF
--- a/Recast/Include/Recast.h
+++ b/Recast/Include/Recast.h
@@ -293,6 +293,9 @@ struct rcSpanPool
 /// @ingroup recast
 struct rcHeightfield
 {
+	rcHeightfield();
+	~rcHeightfield();
+
 	int width;			///< The width of the heightfield. (Along the x-axis in cell units.)
 	int height;			///< The height of the heightfield. (Along the z-axis in cell units.)
 	float bmin[3];  	///< The minimum bounds in world space. [(x, y, z)]
@@ -302,6 +305,11 @@ struct rcHeightfield
 	rcSpan** spans;		///< Heightfield of spans (width*height).
 	rcSpanPool* pools;	///< Linked list of span pools.
 	rcSpan* freelist;	///< The next free span.
+
+private:
+	// Explicitly-disabled copy constructor and copy assignment operator.
+	rcHeightfield(const rcHeightfield&);
+	rcHeightfield& operator=(const rcHeightfield&);
 };
 
 /// Provides information on the content of a cell column in a compact heightfield. 


### PR DESCRIPTION
This adds a default constructor and a destructor to the rcHeightfield struct, and disables the default copy constructor and copy assignment operator.  

While implementing unit tests that use rcHeightfield, there was an observation that rcHeightfield's that aren't made through `rcAllocHeightfield()` and subsequently free'd thorugh `rcFreeHeightfield()` leak memory.  This restricted all rcHeightfield allocations to the heap.  In addition to being an unnecessary constraint that could have adverse performance impacts, it also was causing memory leaks in test cases that couldn't call `rcFreeHeightfield()`.

This shouldn't have any measurable impact on performance, as heightfield's aren't allocated nearly as often as other objects, and the compiler should do a good job of inlining calls to the constructor and destructor where appropriate.