### PR TITLE
Fix memory leak in LinearAllocator used by Sample_TempObstacles

### DIFF
--- a/RecastDemo/Source/Sample_TempObstacles.cpp
+++ b/RecastDemo/Source/Sample_TempObstacles.cpp
@@ -132,11 +132,11 @@ struct FastLZCompressor : public dtTileCacheCompressor
 struct LinearAllocator : public dtTileCacheAlloc
 {
 	unsigned char* buffer;
-	int capacity;
-	int top;
-	int high;
+	size_t capacity;
+	size_t top;
+	size_t high;
 	
-	LinearAllocator(const int cap) : buffer(0), capacity(0), top(0), high(0)
+	LinearAllocator(const size_t cap) : buffer(0), capacity(0), top(0), high(0)
 	{
 		resize(cap);
 	}
@@ -146,7 +146,7 @@ struct LinearAllocator : public dtTileCacheAlloc
 		dtFree(buffer);
 	}
 
-	void resize(const int cap)
+	void resize(const size_t cap)
 	{
 		if (buffer) dtFree(buffer);
 		buffer = (unsigned char*)dtAlloc(cap, DT_ALLOC_PERM);
@@ -159,7 +159,7 @@ struct LinearAllocator : public dtTileCacheAlloc
 		top = 0;
 	}
 	
-	virtual void* alloc(const int size)
+	virtual void* alloc(const size_t size)
 	{
 		if (!buffer)
 			return 0;


### PR DESCRIPTION
Caused by #158.

Can be reproduced by selecting the "Temp Obstacles" sample and pressing build multiple times. Memory will leak because it uses the alloc function from dtTileCacheAlloc and the free function from LinearAllocator (which is empty).

Another improvement would be to change dtTileCacheAlloc to an abstract empty implementation, similar to dtTileCacheCompressor. Existing usage of dtTileCacheAlloc would break though.