### PR TITLE
Add parent indices in Dijkstra searches

### DIFF
--- a/Detour/Include/DetourNavMeshQuery.h
+++ b/Detour/Include/DetourNavMeshQuery.h
@@ -267,15 +267,17 @@ public:
 	///  @param[in]		radius			The radius of the search circle.
 	///  @param[in]		filter			The polygon filter to apply to the query.
 	///  @param[out]	resultRef		The reference ids of the polygons touched by the circle. [opt]
-	///  @param[out]	resultParent	The reference ids of the parent polygons for each result. 
-	///  								Zero if a result polygon has no parent. [opt]
+	///  @param[out]	resultParent	The indices into resultRef of the parent polygons for each result. [opt]
+	///  								-1 if a result polygon has no parent (i.e. for resultRef[0]).
+	///  								If resultRef[i] is a polygon, then resultRef[resultParent[i]] is the
+	///  								reference id of the parent polygon.
 	///  @param[out]	resultCost		The search cost from @p centerPos to the polygon. [opt]
 	///  @param[out]	resultCount		The number of polygons found. [opt]
 	///  @param[in]		maxResult		The maximum number of polygons the result arrays can hold.
 	/// @returns The status flags for the query.
 	dtStatus findPolysAroundCircle(dtPolyRef startRef, const float* centerPos, const float radius,
 								   const dtQueryFilter* filter,
-								   dtPolyRef* resultRef, dtPolyRef* resultParent, float* resultCost,
+								   dtPolyRef* resultRef, int* resultParent, float* resultCost,
 								   int* resultCount, const int maxResult) const;
 	
 	/// Finds the polygons along the naviation graph that touch the specified convex polygon.
@@ -285,15 +287,17 @@ public:
 	///  @param[in]		nverts			The number of vertices in the polygon.
 	///  @param[in]		filter			The polygon filter to apply to the query.
 	///  @param[out]	resultRef		The reference ids of the polygons touched by the search polygon. [opt]
-	///  @param[out]	resultParent	The reference ids of the parent polygons for each result. Zero if a 
-	///  								result polygon has no parent. [opt]
+	///  @param[out]	resultParent	The indices into resultRef of the parent polygons for each result. [opt]
+	///  								-1 if a result polygon has no parent (i.e. for resultRef[0]).
+	///  								If resultRef[i] is a polygon, then resultRef[resultParent[i]] is the
+	///  								reference id of the parent polygon.
 	///  @param[out]	resultCost		The search cost from the centroid point to the polygon. [opt]
 	///  @param[out]	resultCount		The number of polygons found.
 	///  @param[in]		maxResult		The maximum number of polygons the result arrays can hold.
 	/// @returns The status flags for the query.
 	dtStatus findPolysAroundShape(dtPolyRef startRef, const float* verts, const int nverts,
 								  const dtQueryFilter* filter,
-								  dtPolyRef* resultRef, dtPolyRef* resultParent, float* resultCost,
+								  dtPolyRef* resultRef, int* resultParent, float* resultCost,
 								  int* resultCount, const int maxResult) const;
 	
 	/// @}
@@ -337,14 +341,16 @@ public:
 	///  @param[in]		radius			The radius of the query circle.
 	///  @param[in]		filter			The polygon filter to apply to the query.
 	///  @param[out]	resultRef		The reference ids of the polygons touched by the circle.
-	///  @param[out]	resultParent	The reference ids of the parent polygons for each result. 
-	///  								Zero if a result polygon has no parent. [opt]
+	///  @param[out]	resultParent	The indices into resultRef of the parent polygons for each result. [opt]
+	///  								-1 if a result polygon has no parent (i.e. for resultRef[0]).
+	///  								If resultRef[i] is a polygon, then resultRef[resultParent[i]] is the
+	///  								reference id of the parent polygon.
 	///  @param[out]	resultCount		The number of polygons found.
 	///  @param[in]		maxResult		The maximum number of polygons the result arrays can hold.
 	/// @returns The status flags for the query.
 	dtStatus findLocalNeighbourhood(dtPolyRef startRef, const float* centerPos, const float radius,
 									const dtQueryFilter* filter,
-									dtPolyRef* resultRef, dtPolyRef* resultParent,
+									dtPolyRef* resultRef, int* resultParent,
 									int* resultCount, const int maxResult) const;
 
 	/// Moves from the start to the end position constrained to the navigation mesh.

--- a/Detour/Source/DetourNavMeshQuery.cpp
+++ b/Detour/Source/DetourNavMeshQuery.cpp
@@ -2714,9 +2714,9 @@ dtStatus dtNavMeshQuery::raycast(dtPolyRef startRef, const float* startPos, cons
 /// filled to capacity.
 /// 
 dtStatus dtNavMeshQuery::findPolysAroundCircle(dtPolyRef startRef, const float* centerPos, const float radius,
-											   const dtQueryFilter* filter,
-											   dtPolyRef* resultRef, dtPolyRef* resultParent, float* resultCost,
-											   int* resultCount, const int maxResult) const
+                                               const dtQueryFilter* filter,
+                                               dtPolyRef* resultRef, int* resultParent, float* resultCost,
+                                               int* resultCount, const int maxResult) const
 {
 	dtAssert(m_nav);
 	dtAssert(m_nodePool);
@@ -2726,6 +2726,9 @@ dtStatus dtNavMeshQuery::findPolysAroundCircle(dtPolyRef startRef, const float* 
 	
 	// Validate input
 	if (!startRef || !m_nav->isValidPolyRef(startRef))
+		return DT_FAILURE | DT_INVALID_PARAM;
+
+	if (!centerPos || radius < 0 || !filter || !resultRef || !resultCount || maxResult < 0)
 		return DT_FAILURE | DT_INVALID_PARAM;
 	
 	m_nodePool->clear();
@@ -2758,22 +2761,13 @@ dtStatus dtNavMeshQuery::findPolysAroundCircle(dtPolyRef startRef, const float* 
 		const dtMeshTile* bestTile = 0;
 		const dtPoly* bestPoly = 0;
 		m_nav->getTileAndPolyByRefUnsafe(bestRef, &bestTile, &bestPoly);
-		
-		// Get parent poly and tile.
-		dtPolyRef parentRef = 0;
-		const dtMeshTile* parentTile = 0;
-		const dtPoly* parentPoly = 0;
-		if (bestNode->pidx)
-			parentRef = m_nodePool->getNodeAtIdx(bestNode->pidx)->id;
-		if (parentRef)
-			m_nav->getTileAndPolyByRefUnsafe(parentRef, &parentTile, &parentPoly);
 
 		if (n < maxResult)
 		{
-			if (resultRef)
-				resultRef[n] = bestRef;
+			resultRef[n] = bestRef;
+
 			if (resultParent)
-				resultParent[n] = parentRef;
+				resultParent[n] = (int)bestNode->pidx - 1;
 			if (resultCost)
 				resultCost[n] = bestNode->total;
 			++n;
@@ -2782,6 +2776,8 @@ dtStatus dtNavMeshQuery::findPolysAroundCircle(dtPolyRef startRef, const float* 
 		{
 			status |= DT_BUFFER_TOO_SMALL;
 		}
+
+		dtPolyRef parentRef = bestNode->pidx > 0 ? resultRef[bestNode->pidx - 1] : 0;
 		
 		for (unsigned int i = bestPoly->firstLink; i != DT_NULL_LINK; i = bestTile->links[i].next)
 		{
@@ -2832,7 +2828,14 @@ dtStatus dtNavMeshQuery::findPolysAroundCircle(dtPolyRef startRef, const float* 
 				continue;
 			
 			neighbourNode->id = neighbourRef;
-			neighbourNode->pidx = m_nodePool->getNodeIdx(bestNode);
+			// Set the parent to the index into the resultRef
+			// of the parent + 1, i.e. n - 1 + 1. Note that this is
+			// fine even if we overflowed the array as we will always
+			// point back to a polygon in the closed list and we only
+			// use it during the search as an optimization to avoid
+			// recalculating some things for the poly we are expanding to
+			// when we would just skip it anyway.
+			neighbourNode->pidx = (unsigned int)n;
 			neighbourNode->total = total;
 			
 			if (neighbourNode->flags & DT_NODE_OPEN)
@@ -2875,9 +2878,9 @@ dtStatus dtNavMeshQuery::findPolysAroundCircle(dtPolyRef startRef, const float* 
 /// be filled to capacity.
 ///
 dtStatus dtNavMeshQuery::findPolysAroundShape(dtPolyRef startRef, const float* verts, const int nverts,
-											  const dtQueryFilter* filter,
-											  dtPolyRef* resultRef, dtPolyRef* resultParent, float* resultCost,
-											  int* resultCount, const int maxResult) const
+                                              const dtQueryFilter* filter,
+                                              dtPolyRef* resultRef, int* resultParent, float* resultCost,
+                                              int* resultCount, const int maxResult) const
 {
 	dtAssert(m_nav);
 	dtAssert(m_nodePool);
@@ -2888,14 +2891,17 @@ dtStatus dtNavMeshQuery::findPolysAroundShape(dtPolyRef startRef, const float* v
 	// Validate input
 	if (!startRef || !m_nav->isValidPolyRef(startRef))
 		return DT_FAILURE | DT_INVALID_PARAM;
+
+	if (!verts || nverts < 3 || !filter || !resultRef || !resultCount || maxResult < 0)
+		return DT_FAILURE | DT_INVALID_PARAM;
 	
 	m_nodePool->clear();
 	m_openList->clear();
 	
 	float centerPos[3] = {0,0,0};
 	for (int i = 0; i < nverts; ++i)
-		dtVadd(centerPos,centerPos,&verts[i*3]);
-	dtVscale(centerPos,centerPos,1.0f/nverts);
+		dtVadd(centerPos, centerPos, &verts[i * 3]);
+	dtVscale(centerPos, centerPos, 1.0f/nverts);
 
 	dtNode* startNode = m_nodePool->getNode(startRef);
 	dtVcopy(startNode->pos, centerPos);
@@ -2923,21 +2929,12 @@ dtStatus dtNavMeshQuery::findPolysAroundShape(dtPolyRef startRef, const float* v
 		const dtPoly* bestPoly = 0;
 		m_nav->getTileAndPolyByRefUnsafe(bestRef, &bestTile, &bestPoly);
 		
-		// Get parent poly and tile.
-		dtPolyRef parentRef = 0;
-		const dtMeshTile* parentTile = 0;
-		const dtPoly* parentPoly = 0;
-		if (bestNode->pidx)
-			parentRef = m_nodePool->getNodeAtIdx(bestNode->pidx)->id;
-		if (parentRef)
-			m_nav->getTileAndPolyByRefUnsafe(parentRef, &parentTile, &parentPoly);
-
 		if (n < maxResult)
 		{
-			if (resultRef)
-				resultRef[n] = bestRef;
+			resultRef[n] = bestRef;
+
 			if (resultParent)
-				resultParent[n] = parentRef;
+				resultParent[n] = (int)bestNode->pidx - 1;
 			if (resultCost)
 				resultCost[n] = bestNode->total;
 
@@ -2947,6 +2944,8 @@ dtStatus dtNavMeshQuery::findPolysAroundShape(dtPolyRef startRef, const float* v
 		{
 			status |= DT_BUFFER_TOO_SMALL;
 		}
+
+		dtPolyRef parentRef = bestNode->pidx > 0 ? resultRef[bestNode->pidx - 1] : 0;
 		
 		for (unsigned int i = bestPoly->firstLink; i != DT_NULL_LINK; i = bestTile->links[i].next)
 		{
@@ -2999,7 +2998,7 @@ dtStatus dtNavMeshQuery::findPolysAroundShape(dtPolyRef startRef, const float* v
 				continue;
 			
 			neighbourNode->id = neighbourRef;
-			neighbourNode->pidx = m_nodePool->getNodeIdx(bestNode);
+			neighbourNode->pidx = (unsigned int)n;
 			neighbourNode->total = total;
 			
 			if (neighbourNode->flags & DT_NODE_OPEN)
@@ -3042,9 +3041,9 @@ dtStatus dtNavMeshQuery::findPolysAroundShape(dtPolyRef startRef, const float* v
 /// be filled to capacity.
 /// 
 dtStatus dtNavMeshQuery::findLocalNeighbourhood(dtPolyRef startRef, const float* centerPos, const float radius,
-												const dtQueryFilter* filter,
-												dtPolyRef* resultRef, dtPolyRef* resultParent,
-												int* resultCount, const int maxResult) const
+                                                const dtQueryFilter* filter,
+                                                dtPolyRef* resultRef, int* resultParent,
+                                                int* resultCount, const int maxResult) const
 {
 	dtAssert(m_nav);
 	dtAssert(m_tinyNodePool);
@@ -3053,6 +3052,9 @@ dtStatus dtNavMeshQuery::findLocalNeighbourhood(dtPolyRef startRef, const float*
 
 	// Validate input
 	if (!startRef || !m_nav->isValidPolyRef(startRef))
+		return DT_FAILURE | DT_INVALID_PARAM;
+
+	if (!centerPos || radius < 0 || !filter || !resultRef || !resultCount || maxResult < 0)
 		return DT_FAILURE | DT_INVALID_PARAM;
 	
 	static const int MAX_STACK = 48;
@@ -3079,7 +3081,7 @@ dtStatus dtNavMeshQuery::findLocalNeighbourhood(dtPolyRef startRef, const float*
 	{
 		resultRef[n] = startNode->id;
 		if (resultParent)
-			resultParent[n] = 0;
+			resultParent[n] = -1;
 		++n;
 	}
 	else
@@ -3155,9 +3157,13 @@ dtStatus dtNavMeshQuery::findLocalNeighbourhood(dtPolyRef startRef, const float*
 				dtVcopy(&pa[k*3], &neighbourTile->verts[neighbourPoly->verts[k]*3]);
 			
 			bool overlap = false;
+			int curRefIndex = -1;
 			for (int j = 0; j < n; ++j)
 			{
 				dtPolyRef pastRef = resultRef[j];
+
+				if (pastRef == curRef)
+					curRefIndex = j;
 				
 				// Connected polys do not overlap.
 				bool connected = false;
@@ -3196,7 +3202,13 @@ dtStatus dtNavMeshQuery::findLocalNeighbourhood(dtPolyRef startRef, const float*
 			{
 				resultRef[n] = neighbourRef;
 				if (resultParent)
-					resultParent[n] = curRef;
+				{
+					// If we haven't overflowed results we should have a proper
+					// parent.
+					dtAssert(curRefIndex != -1);
+					resultParent[n] = curRefIndex;
+				}
+
 				++n;
 			}
 			else

--- a/DetourCrowd/Source/DetourLocalBoundary.cpp
+++ b/DetourCrowd/Source/DetourLocalBoundary.cpp
@@ -98,7 +98,7 @@ void dtLocalBoundary::update(dtPolyRef ref, const float* pos, const float collis
 	
 	// First query non-overlapping polygons.
 	navquery->findLocalNeighbourhood(ref, pos, collisionQueryRange,
-									 filter, m_polys, 0, &m_npolys, MAX_LOCAL_POLYS);
+	                                 filter, m_polys, 0, &m_npolys, MAX_LOCAL_POLYS);
 	
 	// Secondly, store all polygon edges.
 	m_nsegs = 0;

--- a/RecastDemo/Include/NavMeshTesterTool.h
+++ b/RecastDemo/Include/NavMeshTesterTool.h
@@ -56,7 +56,7 @@ class NavMeshTesterTool : public SampleTool
 	dtPolyRef m_startRef;
 	dtPolyRef m_endRef;
 	dtPolyRef m_polys[MAX_POLYS];
-	dtPolyRef m_parent[MAX_POLYS];
+	int m_parent[MAX_POLYS];
 	int m_npolys;
 	float m_straightPath[MAX_POLYS*3];
 	unsigned char m_straightPathFlags[MAX_POLYS];

--- a/RecastDemo/Source/NavMeshTesterTool.cpp
+++ b/RecastDemo/Source/NavMeshTesterTool.cpp
@@ -956,7 +956,7 @@ void NavMeshTesterTool::recalc()
 				   m_filter.getIncludeFlags(), m_filter.getExcludeFlags());
 #endif
 			m_navQuery->findPolysAroundCircle(m_startRef, m_spos, dist, &m_filter,
-											  m_polys, m_parent, 0, &m_npolys, MAX_POLYS);
+			                                  m_polys, m_parent, 0, &m_npolys, MAX_POLYS);
 
 		}
 	}
@@ -993,7 +993,7 @@ void NavMeshTesterTool::recalc()
 				   m_filter.getIncludeFlags(), m_filter.getExcludeFlags());
 #endif
 			m_navQuery->findPolysAroundShape(m_startRef, m_queryPoly, 4, &m_filter,
-											 m_polys, m_parent, 0, &m_npolys, MAX_POLYS);
+			                                 m_polys, m_parent, 0, &m_npolys, MAX_POLYS);
 		}
 	}
 	else if (m_toolMode == TOOLMODE_FIND_LOCAL_NEIGHBOURHOOD)
@@ -1006,7 +1006,7 @@ void NavMeshTesterTool::recalc()
 				   m_filter.getIncludeFlags(), m_filter.getExcludeFlags());
 #endif
 			m_navQuery->findLocalNeighbourhood(m_startRef, m_spos, m_neighbourhoodRadius, &m_filter,
-											   m_polys, m_parent, &m_npolys, MAX_POLYS);
+			                                   m_polys, m_parent, &m_npolys, MAX_POLYS);
 		}
 	}
 }
@@ -1226,11 +1226,11 @@ void NavMeshTesterTool::handleRender()
 		{
 			duDebugDrawNavMeshPoly(&dd, *m_navMesh, m_polys[i], pathCol);
 			dd.depthMask(false);
-			if (m_parent[i])
+			if (m_parent[i] >= 0)
 			{
 				float p0[3], p1[3];
 				dd.depthMask(false);
-				getPolyCenter(m_navMesh, m_parent[i], p0);
+				getPolyCenter(m_navMesh, m_polys[m_parent[i]], p0);
 				getPolyCenter(m_navMesh, m_polys[i], p1);
 				duDebugDrawArc(&dd, p0[0],p0[1],p0[2], p1[0],p1[1],p1[2], 0.25f, 0.0f, 0.4f, duRGBA(0,0,0,128), 2.0f);
 				dd.depthMask(true);
@@ -1254,11 +1254,11 @@ void NavMeshTesterTool::handleRender()
 		{
 			duDebugDrawNavMeshPoly(&dd, *m_navMesh, m_polys[i], pathCol);
 			dd.depthMask(false);
-			if (m_parent[i])
+			if (m_parent[i] >= 0)
 			{
 				float p0[3], p1[3];
 				dd.depthMask(false);
-				getPolyCenter(m_navMesh, m_parent[i], p0);
+				getPolyCenter(m_navMesh, m_polys[m_parent[i]], p0);
 				getPolyCenter(m_navMesh, m_polys[i], p1);
 				duDebugDrawArc(&dd, p0[0],p0[1],p0[2], p1[0],p1[1],p1[2], 0.25f, 0.0f, 0.4f, duRGBA(0,0,0,128), 2.0f);
 				dd.depthMask(true);
@@ -1288,11 +1288,11 @@ void NavMeshTesterTool::handleRender()
 		{
 			duDebugDrawNavMeshPoly(&dd, *m_navMesh, m_polys[i], pathCol);
 			dd.depthMask(false);
-			if (m_parent[i])
+			if (m_parent[i] >= 0)
 			{
 				float p0[3], p1[3];
 				dd.depthMask(false);
-				getPolyCenter(m_navMesh, m_parent[i], p0);
+				getPolyCenter(m_navMesh, m_polys[m_parent[i]], p0);
 				getPolyCenter(m_navMesh, m_polys[i], p1);
 				duDebugDrawArc(&dd, p0[0],p0[1],p0[2], p1[0],p1[1],p1[2], 0.25f, 0.0f, 0.4f, duRGBA(0,0,0,128), 2.0f);
 				dd.depthMask(true);


### PR DESCRIPTION
This changes the `findPolysAroundCircle`, `findPolysAroundShape` and
`findLocalNeighbourhood` functions to return indices into the poly array
for the parents, instead of returning the polygon references. This makes
it much more convenient to retrace paths after performing the searches,
based on the parent arrays.

Also make some arguments to the aforementioned functions required as the
APIs are not very useful without them. Update documentation to specify
this and perform addition parameter validation.

Fix #206

**Note: This change is breaking in the following ways:**
1. The functions now fail if null is passed for `resultRef`. Doing this does not result in anything useful, and having the results simplifies the implementation.
2. `resultParent` from `dtPolyRef` to `int`
3. `dtNode::pidx` now represents indices into the `resultRef` array during and after the Dijkstra searches rather than representing indices into the node pool. This is breaking since the node pool is public.

Of these I think number three is the worst. This implementation has the least overhead, but it's a little iffy since it uses `dtNode::pidx` in a different way than other functions. For that reason I am not actually convinced this change is worth it in the form in this PR since the node pool is publicly exposed and can be used for the scenario I describe in #206.