### PR TITLE
Add getPathFromSearch function

### DIFF
--- a/Detour/Include/DetourNavMeshQuery.h
+++ b/Detour/Include/DetourNavMeshQuery.h
@@ -193,7 +193,7 @@ public:
 					  const float* startPos, const float* endPos,
 					  const dtQueryFilter* filter,
 					  dtPolyRef* path, int* pathCount, const int maxPath) const;
-	
+
 	/// Finds the straight path from the start to the end position within the polygon corridor.
 	///  @param[in]		startPos			Path start position. [(x, y, z)]
 	///  @param[in]		endPos				Path end position. [(x, y, z)]
@@ -296,6 +296,20 @@ public:
 								  dtPolyRef* resultRef, dtPolyRef* resultParent, float* resultCost,
 								  int* resultCount, const int maxResult) const;
 	
+	/// Gets a path from the explored nodes in the previous search.
+	///  @param[in]		endRef		The reference id of the end polygon.
+	///  @param[out]	path		An ordered list of polygon references representing the path. (Start to end.)
+	///  							[(polyRef) * @p pathCount]
+	///  @param[out]	pathCount	The number of polygons returned in the @p path array.
+	///  @param[in]		maxPath		The maximum number of polygons the @p path array can hold. [Limit: >= 0]
+	///  @returns		The status flags. Returns DT_FAILURE | DT_INVALID_PARAM if any parameter is wrong, or if
+	///  				@p endRef was not explored in the previous search. Returns DT_SUCCESS | DT_BUFFER_TOO_SMALL
+	///  				if @p path cannot contain the entire path. In this case it is filled to capacity with a partial path.
+	///  				Otherwise returns DT_SUCCESS.
+	///  @remarks		The result of this function depends on the state of the query object. For that reason it should only
+	///  				be used immediately after one of the two Dijkstra searches, findPolysAroundCircle or findPolysAroundShape.
+	dtStatus getPathFromDijkstraSearch(dtPolyRef endRef, dtPolyRef* path, int* pathCount, int maxPath) const;
+
 	/// @}
 	/// @name Local Query Functions
 	///@{
@@ -524,6 +538,9 @@ private:
 	dtStatus appendPortals(const int startIdx, const int endIdx, const float* endPos, const dtPolyRef* path,
 						   float* straightPath, unsigned char* straightPathFlags, dtPolyRef* straightPathRefs,
 						   int* straightPathCount, const int maxStraightPath, const int options) const;
+
+	// Gets the path leading to the specified end node.
+	dtStatus getPathToNode(class dtNode* endNode, dtPolyRef* path, int* pathCount, int maxPath) const;
 	
 	const dtNavMesh* m_nav;				///< Pointer to navmesh data.
 


### PR DESCRIPTION
This adds a method to dtNavMeshQuery that allows users to retrieve paths
from the nodes explored by the previous search. This is especially
useful after Dijkstra searches to retrieve arbitrary paths inside the
explored circle.

As expected the removal of the fast path in `findPath` hurts its execution time pretty badly for paths of length 1:

| Resulting path length | Number of nodes | New time per query | Old time per query |
| --------------------- | --------------- | ------------------ | ------------------ |
| 1 | 32 | 0.042376 µs | 0.017040 µs |
| 1 | 64 | 0.045196 µs | 0.014216 µs |
| 1 | 128 | 0.044628 µs | 0.015892 µs |
| 1 | 256 | 0.052404 µs | 0.014280 µs |
| 1 | 512 | 0.058444 µs | 0.014332 µs |
| 1 | 1024 | 0.058892 µs | 0.015176 µs |
| 1 | 2048 | 0.064912 µs | 0.014220 µs |
| 1 | 4096 | 0.074812 µs | 0.014408 µs |
| 1 | 8192 | 0.079124 µs | 0.014212 µs |
| 1 | 16384 | 0.180380 µs | 0.014220 µs |
| 1 | 32768 | 0.319872 µs | 0.014212 µs |
| 1 | 65535 | 0.615928 µs | 0.015844 µs |
| 6 | 32 | 0.534080 µs | 0.544984 µs |
| 6 | 64 | 0.566268 µs | 0.544760 µs |
| 6 | 128 | 0.531872 µs | 0.569724 µs |
| 6 | 256 | 0.530992 µs | 0.548216 µs |
| 6 | 512 | 0.546624 µs | 0.594020 µs |
| 6 | 1024 | 0.550972 µs | 0.554668 µs |
| 6 | 2048 | 0.557312 µs | 0.609808 µs |
| 6 | 4096 | 0.580524 µs | 0.588544 µs |
| 6 | 8192 | 0.606872 µs | 0.635160 µs |
| 6 | 16384 | 0.613704 µs | 0.698412 µs |
| 6 | 32768 | 0.659844 µs | 0.696372 µs |
| 6 | 65535 | 1.175344 µs | 1.040392 µs |
| 26 | 128 | 8.144044 µs | 8.166928 µs |
| 26 | 256 | 8.043796 µs | 8.084444 µs |
| 26 | 512 | 7.986532 µs | 8.046808 µs |
| 26 | 1024 | 7.996000 µs | 8.992956 µs |
| 26 | 2048 | 7.927116 µs | 10.129456 µs |
| 26 | 4096 | 7.896920 µs | 8.644568 µs |
| 26 | 8192 | 8.089548 µs | 8.326412 µs |
| 26 | 16384 | 8.172776 µs | 8.335688 µs |
| 26 | 32768 | 8.377008 µs | 8.224712 µs |
| 26 | 65535 | 8.695988 µs | 8.691952 µs |

We see a pretty drastic speed difference in the top 12 rows. Most of this time is spent clearing the node pool - it cannot be avoided if we want `findPath` to be consistent with the other search functions for the new `getPathFromSearch` function. Do keep in mind that these numbers are very low; the new version is still able to generate 1.6 million paths of length 1 per second on my machine, at the largest of our default supported node pool sizes.

As expected there are no noticeable differences for the other cases where the length of the path is larger than 1.