### PR TITLE
Add .editorconfig with tabs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+# editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_size = 4
+indent_style = tab


### PR DESCRIPTION
This file specifies the indentation settings used in R&D. This should help keep the code base consistent.
It is very useful when you are switching between multiple projects with different indentations,
or when you have multiple developers with different environment.

Some IDEs support parsing this file format out of the box, and otherwise there exist lightweight plugins that parses the file format and applies the settings for virtually all IDEs.

See http://editorconfig.org/.