### PR TITLE
Add an assertion for alloc in rcIntArray::doResize

### DIFF
--- a/Recast/Source/RecastAlloc.cpp
+++ b/Recast/Source/RecastAlloc.cpp
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "RecastAlloc.h"
+#include "RecastAssert.h"
 
 static void *rcAllocDefault(size_t size, rcAllocHint)
 {
@@ -77,6 +78,7 @@ void rcIntArray::doResize(int n)
 	if (!m_cap) m_cap = n;
 	while (m_cap < n) m_cap *= 2;
 	int* newData = (int*)rcAlloc(m_cap*sizeof(int), RC_ALLOC_TEMP);
+	rcAssert(newData);
 	if (m_size && newData) memcpy(newData, m_data, m_size*sizeof(int));
 	rcFree(m_data);
 	m_data = newData;


### PR DESCRIPTION
Fix #170 

Initially I wanted to do better error checking and handle the allocation failures
by returning errors from the APIs. However, there are very many usages and
since we do not use exceptions in the core this approach significantly worsens the code.

Since the `rcIntArray` usages are generally for small arrays I think just an assertion is fine,
while we can let the Recast fail if the bigger allocations fail.