### PR TITLE
Fix a small typo in an error check

### DIFF
--- a/Detour/Source/DetourNavMeshQuery.cpp
+++ b/Detour/Source/DetourNavMeshQuery.cpp
@@ -481,9 +481,9 @@ dtStatus dtNavMeshQuery::findRandomPointAroundCircle(dtPolyRef startRef, const f
 	dtRandomPointInConvexPoly(verts, randomPoly->vertCount, areas, s, t, pt);
 	
 	float h = 0.0f;
-	dtStatus stat = getPolyHeight(randomPolyRef, pt, &h);
+	status = getPolyHeight(randomPolyRef, pt, &h);
 	if (dtStatusFailed(status))
-		return stat;
+		return status;
 	pt[1] = h;
 	
 	dtVcopy(randomPt, pt);


### PR DESCRIPTION
Just a tiny fix - wrong `dtStatus` variable was used here.