### PR TITLE
Set warnings as errors on Linux

### DIFF
--- a/RecastDemo/premake5.lua
+++ b/RecastDemo/premake5.lua
@@ -37,6 +37,12 @@ solution "recastnavigation"
 	configuration "windows"
 		defines { "WIN32", "_WINDOWS", "_CRT_SECURE_NO_WARNINGS" }
 
+	-- linux specific
+	configuration { "linux", "gmake" }
+		buildoptions {
+			"-Wall",
+			"-Werror"
+		}
 
 project "DebugUtils"
 	language "C++"
@@ -215,7 +221,8 @@ project "Tests"
 		buildoptions { 
 			"`pkg-config --cflags sdl2`",
 			"`pkg-config --cflags gl`",
-			"`pkg-config --cflags glu`" 
+			"`pkg-config --cflags glu`",
+			"-Wno-parentheses" -- Disable parentheses warning for the Tests target, as Catch's macros generate this everywhere.
 		}
 		linkoptions { 
 			"`pkg-config --libs sdl2`",


### PR DESCRIPTION
Once #245 is merged, this should pass. It'll be nice to have warnings as errors for one CI platform!

It'll be much harder to do with AppVeyor since on Windows we get a ton of warnings about exception handling. Not sure how to tackle that for now.