### PR TITLE
Suppress warnings when compiling for VS2015

### DIFF
--- a/RecastDemo/Contrib/fastlz/fastlz.c
+++ b/RecastDemo/Contrib/fastlz/fastlz.c
@@ -81,6 +81,11 @@ typedef unsigned char  flzuint8;
 typedef unsigned short flzuint16;
 typedef unsigned int   flzuint32;
 
+/* Disable "conversion from A to B, possible loss of data" warning when using MSVC */
+#if defined(_MSC_VER)
+#pragma warning(disable: 4244)
+#endif
+
 /* prototypes */
 int fastlz_compress(const void* input, int length, void* output);
 int fastlz_compress_level(int level, const void* input, int length, void* output);

--- a/RecastDemo/premake5.lua
+++ b/RecastDemo/premake5.lua
@@ -35,7 +35,7 @@ solution "recastnavigation"
 
 	-- windows specific
 	configuration "windows"
-		defines { "WIN32", "_WINDOWS", "_CRT_SECURE_NO_WARNINGS" }
+		defines { "WIN32", "_WINDOWS", "_CRT_SECURE_NO_WARNINGS", "_HAS_EXCEPTIONS=0" }
 
 	-- linux specific
 	configuration { "linux", "gmake" }


### PR DESCRIPTION
The change to fastlz.c could also be implemented via "/wd4244" appropriately placed in premake5.lua