### PR TITLE
Change back to previous default color

### DIFF
--- a/RecastDemo/Source/Sample.cpp
+++ b/RecastDemo/Source/Sample.cpp
@@ -39,12 +39,12 @@ unsigned int SampleDebugDraw::areaToCol(unsigned int area)
 {
 	switch(area)
 	{
-	// Ground (0) : brown
-	case SAMPLE_POLYAREA_GROUND: return duRGBA(125, 125, 0, 255);
+	// Ground (0) : light blue
+	case SAMPLE_POLYAREA_GROUND: return duRGBA(0, 192, 255, 255);
 	// Water : blue
 	case SAMPLE_POLYAREA_WATER: return duRGBA(0, 0, 255, 255);
-	// Road : dark grey
-	case SAMPLE_POLYAREA_ROAD: return duRGBA(80, 80, 80, 255);
+	// Road : brown
+	case SAMPLE_POLYAREA_ROAD: return duRGBA(50, 20, 12, 255);
 	// Door : cyan
 	case SAMPLE_POLYAREA_DOOR: return duRGBA(0, 255, 255, 255);
 	// Grass : green


### PR DESCRIPTION
I was a bit too fast to merge #254 before checking how the colors actually look.
Turns out the new default color changed significantly; change it back to the old original to retain that look.