### PR TITLE
Added option to add rotated Box obstacle to TileCache.

### DIFF
--- a/DetourTileCache/Include/DetourTileCache.h
+++ b/DetourTileCache/Include/DetourTileCache.h
@@ -38,8 +38,8 @@ enum ObstacleState
 enum ObstacleType
 {
 	DT_OBSTACLE_CYLINDER,
-	DT_OBSTACLE_AABB,
-	DT_OBSTACLE_BOX,
+	DT_OBSTACLE_BOX, // AABB
+	DT_OBSTACLE_ORIENTED_BOX, // OBB
 };
 
 struct dtObstacleCylinder
@@ -49,17 +49,17 @@ struct dtObstacleCylinder
 	float height;
 };
 
-struct dtObstacleAabb
+struct dtObstacleBox
 {
 	float bmin[ 3 ];
 	float bmax[ 3 ];
 };
 
-struct dtObstacleBox
+struct dtObstacleOrientedBox
 {
 	float center[ 3 ];
-	float halfextents[ 3 ];
-	float rotaux[ 2 ]; //{ cos(0.5f*angle)*sin(-0.5f*angle); cos(0.5f*angle)*cos(0.5f*angle) - 0.5 }
+	float halfExtents[ 3 ];
+	float rotAux[ 2 ]; //{ cos(0.5f*angle)*sin(-0.5f*angle); cos(0.5f*angle)*cos(0.5f*angle) - 0.5 }
 };
 
 static const int DT_MAX_TOUCHED_TILES = 8;
@@ -68,8 +68,8 @@ struct dtTileCacheObstacle
 	union
 	{
 		dtObstacleCylinder cylinder;
-		dtObstacleAabb aabb;
 		dtObstacleBox box;
+		dtObstacleOrientedBox orientedBox;
 	};
 
 	dtCompressedTileRef touched[DT_MAX_TOUCHED_TILES];

--- a/DetourTileCache/Include/DetourTileCache.h
+++ b/DetourTileCache/Include/DetourTileCache.h
@@ -58,7 +58,7 @@ struct dtObstacleBox
 struct dtObstacleOrientedBox
 {
 	float center[ 3 ];
-	float halfExtents[ 3 ];
+	float extents[ 3 ];
 	float rotAux[ 2 ]; //{ cos(0.5f*angle)*sin(-0.5f*angle); cos(0.5f*angle)*cos(0.5f*angle) - 0.5 }
 };
 
@@ -145,8 +145,8 @@ public:
 	// Aabb obstacle.
 	dtStatus addBoxObstacle(const float* bmin, const float* bmax, dtObstacleRef* result);
 
-	// Obb obstacle: can be rotated in Y.
-	dtStatus addBoxObstacle(const float* bmin, const float* bmax, const float yRadians, dtObstacleRef* result);
+	// Box obstacle: can be rotated in Y.
+	dtStatus addBoxObstacle(const float* center, const float* extents, const float yRadians, dtObstacleRef* result);
 	
 	dtStatus removeObstacle(const dtObstacleRef ref);
 	

--- a/DetourTileCache/Include/DetourTileCache.h
+++ b/DetourTileCache/Include/DetourTileCache.h
@@ -145,7 +145,7 @@ public:
 	// Aabb obstacle.
 	dtStatus addBoxObstacle(const float* bmin, const float* bmax, dtObstacleRef* result);
 
-	// Box obstacle: can be rotated in Y.
+	// Obb obstacle: can be rotated in Y.
 	dtStatus addBoxObstacle(const float* bmin, const float* bmax, const float yRadians, dtObstacleRef* result);
 	
 	dtStatus removeObstacle(const dtObstacleRef ref);

--- a/DetourTileCache/Include/DetourTileCache.h
+++ b/DetourTileCache/Include/DetourTileCache.h
@@ -38,6 +38,7 @@ enum ObstacleState
 enum ObstacleType
 {
 	DT_OBSTACLE_CYLINDER,
+	DT_OBSTACLE_AABB,
 	DT_OBSTACLE_BOX,
 };
 
@@ -48,10 +49,17 @@ struct dtObstacleCylinder
 	float height;
 };
 
-struct dtObstacleBox
+struct dtObstacleAabb
 {
 	float bmin[ 3 ];
 	float bmax[ 3 ];
+};
+
+struct dtObstacleBox
+{
+	float center[ 3 ];
+	float halfextents[ 3 ];
+	float rotaux[ 2 ]; //{ cos(0.5f*angle)*sin(-0.5f*angle); cos(0.5f*angle)*cos(0.5f*angle) - 0.5 }
 };
 
 static const int DT_MAX_TOUCHED_TILES = 8;
@@ -60,6 +68,7 @@ struct dtTileCacheObstacle
 	union
 	{
 		dtObstacleCylinder cylinder;
+		dtObstacleAabb aabb;
 		dtObstacleBox box;
 	};
 
@@ -130,8 +139,14 @@ public:
 	
 	dtStatus removeTile(dtCompressedTileRef ref, unsigned char** data, int* dataSize);
 	
+	// Cylinder obstacle.
 	dtStatus addObstacle(const float* pos, const float radius, const float height, dtObstacleRef* result);
+
+	// Aabb obstacle.
 	dtStatus addBoxObstacle(const float* bmin, const float* bmax, dtObstacleRef* result);
+
+	// Box obstacle: can be rotated in Y.
+	dtStatus addBoxObstacle(const float* bmin, const float* bmax, const float yRadians, dtObstacleRef* result);
 	
 	dtStatus removeObstacle(const dtObstacleRef ref);
 	

--- a/DetourTileCache/Include/DetourTileCacheBuilder.h
+++ b/DetourTileCache/Include/DetourTileCacheBuilder.h
@@ -131,7 +131,7 @@ dtStatus dtMarkBoxArea(dtTileCacheLayer& layer, const float* orig, const float c
 					   const float* bmin, const float* bmax, const unsigned char areaId);
 
 dtStatus dtMarkBoxArea(dtTileCacheLayer& layer, const float* orig, const float cs, const float ch,
-					   const float* center, const float* halfextents, const float* rotaux, const unsigned char areaId);
+					   const float* center, const float* halfExtents, const float* rotAux, const unsigned char areaId);
 
 dtStatus dtBuildTileCacheRegions(dtTileCacheAlloc* alloc,
 								 dtTileCacheLayer& layer,

--- a/DetourTileCache/Include/DetourTileCacheBuilder.h
+++ b/DetourTileCache/Include/DetourTileCacheBuilder.h
@@ -131,7 +131,7 @@ dtStatus dtMarkBoxArea(dtTileCacheLayer& layer, const float* orig, const float c
 					   const float* bmin, const float* bmax, const unsigned char areaId);
 
 dtStatus dtMarkBoxArea(dtTileCacheLayer& layer, const float* orig, const float cs, const float ch,
-					   const float* center, const float* halfExtents, const float* rotAux, const unsigned char areaId);
+					   const float* center, const float* extents, const float* rotAux, const unsigned char areaId);
 
 dtStatus dtBuildTileCacheRegions(dtTileCacheAlloc* alloc,
 								 dtTileCacheLayer& layer,

--- a/DetourTileCache/Include/DetourTileCacheBuilder.h
+++ b/DetourTileCache/Include/DetourTileCacheBuilder.h
@@ -130,6 +130,9 @@ dtStatus dtMarkCylinderArea(dtTileCacheLayer& layer, const float* orig, const fl
 dtStatus dtMarkBoxArea(dtTileCacheLayer& layer, const float* orig, const float cs, const float ch,
 					   const float* bmin, const float* bmax, const unsigned char areaId);
 
+dtStatus dtMarkBoxArea(dtTileCacheLayer& layer, const float* orig, const float cs, const float ch,
+					   const float* center, const float* halfextents, const float* rotaux, const unsigned char areaId);
+
 dtStatus dtBuildTileCacheRegions(dtTileCacheAlloc* alloc,
 								 dtTileCacheLayer& layer,
 								 const int walkableClimb);

--- a/DetourTileCache/Source/DetourTileCache.cpp
+++ b/DetourTileCache/Source/DetourTileCache.cpp
@@ -420,7 +420,7 @@ dtStatus dtTileCache::addBoxObstacle(const float* bmin, const float* bmax, dtObs
 	return DT_SUCCESS;
 }
 
-dtStatus dtTileCache::addBoxObstacle(const float* center, const float* halfExtents, const float yRadians, dtObstacleRef* result)
+dtStatus dtTileCache::addBoxObstacle(const float* center, const float* extents, const float yRadians, dtObstacleRef* result)
 {
 	if (m_nreqs >= MAX_REQUESTS)
 		return DT_FAILURE | DT_BUFFER_TOO_SMALL;
@@ -441,7 +441,7 @@ dtStatus dtTileCache::addBoxObstacle(const float* center, const float* halfExten
 	ob->state = DT_OBSTACLE_PROCESSING;
 	ob->type = DT_OBSTACLE_ORIENTED_BOX;
 	dtVcopy(ob->orientedBox.center, center);
-	dtVcopy(ob->orientedBox.halfExtents, halfExtents);
+	dtVcopy(ob->orientedBox.extents, extents);
 
 	float coshalf= cosf(0.5f*yRadians);
 	float sinhalf = sinf(-0.5f*yRadians);
@@ -694,7 +694,7 @@ dtStatus dtTileCache::buildNavMeshTile(const dtCompressedTileRef ref, dtNavMesh*
 			else if (ob->type == DT_OBSTACLE_ORIENTED_BOX)
 			{
 				dtMarkBoxArea(*bc.layer, tile->header->bmin, m_params.cs, m_params.ch,
-					ob->orientedBox.center, ob->orientedBox.halfExtents, ob->orientedBox.rotAux, 0);
+					ob->orientedBox.center, ob->orientedBox.extents, ob->orientedBox.rotAux, 0);
 			}
 		}
 	}
@@ -809,11 +809,11 @@ void dtTileCache::getObstacleBounds(const struct dtTileCacheObstacle* ob, float*
 	{
 		const dtObstacleOrientedBox &orientedBox = ob->orientedBox;
 
-		float maxr = 1.41f*dtMax(orientedBox.halfExtents[0], orientedBox.halfExtents[2]);
+		float maxr = 1.41f*dtMax(orientedBox.extents[0], orientedBox.extents[2]);
 		bmin[0] = orientedBox.center[0] - maxr;
 		bmax[0] = orientedBox.center[0] + maxr;
-		bmin[1] = orientedBox.center[1] - orientedBox.halfExtents[1];
-		bmax[1] = orientedBox.center[1] + orientedBox.halfExtents[1];
+		bmin[1] = orientedBox.center[1] - orientedBox.extents[1];
+		bmax[1] = orientedBox.center[1] + orientedBox.extents[1];
 		bmin[2] = orientedBox.center[2] - maxr;
 		bmax[2] = orientedBox.center[2] + maxr;
 	}

--- a/DetourTileCache/Source/DetourTileCache.cpp
+++ b/DetourTileCache/Source/DetourTileCache.cpp
@@ -405,9 +405,9 @@ dtStatus dtTileCache::addBoxObstacle(const float* bmin, const float* bmax, dtObs
 	memset(ob, 0, sizeof(dtTileCacheObstacle));
 	ob->salt = salt;
 	ob->state = DT_OBSTACLE_PROCESSING;
-	ob->type = DT_OBSTACLE_AABB;
-	dtVcopy(ob->aabb.bmin, bmin);
-	dtVcopy(ob->aabb.bmax, bmax);
+	ob->type = DT_OBSTACLE_BOX;
+	dtVcopy(ob->box.bmin, bmin);
+	dtVcopy(ob->box.bmax, bmax);
 	
 	ObstacleRequest* req = &m_reqs[m_nreqs++];
 	memset(req, 0, sizeof(ObstacleRequest));
@@ -420,7 +420,7 @@ dtStatus dtTileCache::addBoxObstacle(const float* bmin, const float* bmax, dtObs
 	return DT_SUCCESS;
 }
 
-dtStatus dtTileCache::addBoxObstacle(const float* center, const float* halfextents, const float yRadians, dtObstacleRef* result)
+dtStatus dtTileCache::addBoxObstacle(const float* center, const float* halfExtents, const float yRadians, dtObstacleRef* result)
 {
 	if (m_nreqs >= MAX_REQUESTS)
 		return DT_FAILURE | DT_BUFFER_TOO_SMALL;
@@ -439,14 +439,14 @@ dtStatus dtTileCache::addBoxObstacle(const float* center, const float* halfexten
 	memset(ob, 0, sizeof(dtTileCacheObstacle));
 	ob->salt = salt;
 	ob->state = DT_OBSTACLE_PROCESSING;
-	ob->type = DT_OBSTACLE_BOX;
-	dtVcopy(ob->box.center, center);
-	dtVcopy(ob->box.halfextents, halfextents);
+	ob->type = DT_OBSTACLE_ORIENTED_BOX;
+	dtVcopy(ob->orientedBox.center, center);
+	dtVcopy(ob->orientedBox.halfExtents, halfExtents);
 
 	float coshalf= cosf(0.5f*yRadians);
 	float sinhalf = sinf(-0.5f*yRadians);
-	ob->box.rotaux[0] = coshalf*sinhalf;
-	ob->box.rotaux[1] = coshalf*coshalf - 0.5f;
+	ob->orientedBox.rotAux[0] = coshalf*sinhalf;
+	ob->orientedBox.rotAux[1] = coshalf*coshalf - 0.5f;
 
 	ObstacleRequest* req = &m_reqs[m_nreqs++];
 	memset(req, 0, sizeof(ObstacleRequest));
@@ -686,15 +686,15 @@ dtStatus dtTileCache::buildNavMeshTile(const dtCompressedTileRef ref, dtNavMesh*
 				dtMarkCylinderArea(*bc.layer, tile->header->bmin, m_params.cs, m_params.ch,
 							    ob->cylinder.pos, ob->cylinder.radius, ob->cylinder.height, 0);
 			}
-			else if (ob->type == DT_OBSTACLE_AABB)
-			{
-				dtMarkBoxArea(*bc.layer, tile->header->bmin, m_params.cs, m_params.ch,
-					ob->aabb.bmin, ob->aabb.bmax, 0);
-			}
 			else if (ob->type == DT_OBSTACLE_BOX)
 			{
 				dtMarkBoxArea(*bc.layer, tile->header->bmin, m_params.cs, m_params.ch,
-					ob->box.center, ob->box.halfextents, ob->box.rotaux, 0);
+					ob->box.bmin, ob->box.bmax, 0);
+			}
+			else if (ob->type == DT_OBSTACLE_ORIENTED_BOX)
+			{
+				dtMarkBoxArea(*bc.layer, tile->header->bmin, m_params.cs, m_params.ch,
+					ob->orientedBox.center, ob->orientedBox.halfExtents, ob->orientedBox.rotAux, 0);
 			}
 		}
 	}
@@ -800,21 +800,21 @@ void dtTileCache::getObstacleBounds(const struct dtTileCacheObstacle* ob, float*
 		bmax[1] = cl.pos[1] + cl.height;
 		bmax[2] = cl.pos[2] + cl.radius;
 	}
-	else if (ob->type == DT_OBSTACLE_AABB)
-	{
-		dtVcopy(bmin, ob->aabb.bmin);
-		dtVcopy(bmax, ob->aabb.bmax);
-	}
 	else if (ob->type == DT_OBSTACLE_BOX)
 	{
-		const dtObstacleBox &box = ob->box;
+		dtVcopy(bmin, ob->box.bmin);
+		dtVcopy(bmax, ob->box.bmax);
+	}
+	else if (ob->type == DT_OBSTACLE_ORIENTED_BOX)
+	{
+		const dtObstacleOrientedBox &orientedBox = ob->orientedBox;
 
-		float maxr = 1.41f*dtMax(box.halfextents[0], box.halfextents[2]);
-		bmin[0] = box.center[0] - maxr;
-		bmax[0] = box.center[0] + maxr;
-		bmin[1] = box.center[1] - box.halfextents[1];
-		bmax[1] = box.center[1] + box.halfextents[1];
-		bmin[2] = box.center[2] - maxr;
-		bmax[2] = box.center[2] + maxr;
+		float maxr = 1.41f*dtMax(orientedBox.halfExtents[0], orientedBox.halfExtents[2]);
+		bmin[0] = orientedBox.center[0] - maxr;
+		bmax[0] = orientedBox.center[0] + maxr;
+		bmin[1] = orientedBox.center[1] - orientedBox.halfExtents[1];
+		bmax[1] = orientedBox.center[1] + orientedBox.halfExtents[1];
+		bmin[2] = orientedBox.center[2] - maxr;
+		bmax[2] = orientedBox.center[2] + maxr;
 	}
 }

--- a/DetourTileCache/Source/DetourTileCacheBuilder.cpp
+++ b/DetourTileCache/Source/DetourTileCacheBuilder.cpp
@@ -2042,7 +2042,7 @@ dtStatus dtMarkBoxArea(dtTileCacheLayer& layer, const float* orig, const float c
 }
 
 dtStatus dtMarkBoxArea(dtTileCacheLayer& layer, const float* orig, const float cs, const float ch,
-					   const float* center, const float* halfextents, const float* rotaux, const unsigned char areaId)
+					   const float* center, const float* halfExtents, const float* rotAux, const unsigned char areaId)
 {
 	const int w = (int)layer.header->width;
 	const int h = (int)layer.header->height;
@@ -2052,13 +2052,13 @@ dtStatus dtMarkBoxArea(dtTileCacheLayer& layer, const float* orig, const float c
 	float cx = (center[0] - orig[0])*ics;
 	float cz = (center[2] - orig[2])*ics;
 	
-	float maxr = 1.41f*dtMax(halfextents[0], halfextents[2]);
+	float maxr = 1.41f*dtMax(halfExtents[0], halfExtents[2]);
 	int minx = (int)floorf(cx - maxr*ics);
 	int maxx = (int)floorf(cx + maxr*ics);
 	int minz = (int)floorf(cz - maxr*ics);
 	int maxz = (int)floorf(cz + maxr*ics);
-	int miny = (int)floorf((center[1]-halfextents[1]-orig[1])*ich);
-	int maxy = (int)floorf((center[1]+halfextents[1]-orig[1])*ich);
+	int miny = (int)floorf((center[1]-halfExtents[1]-orig[1])*ich);
+	int maxy = (int)floorf((center[1]+halfExtents[1]-orig[1])*ich);
 
 	if (maxx < 0) return DT_SUCCESS;
 	if (minx >= w) return DT_SUCCESS;
@@ -2070,8 +2070,8 @@ dtStatus dtMarkBoxArea(dtTileCacheLayer& layer, const float* orig, const float c
 	if (minz < 0) minz = 0;
 	if (maxz >= h) maxz = h-1;
 	
-	float xhalf = halfextents[0]*ics + 0.5f;
-	float zhalf = halfextents[2]*ics + 0.5f;
+	float xhalf = halfExtents[0]*ics + 0.5f;
+	float zhalf = halfExtents[2]*ics + 0.5f;
 
 	for (int z = minz; z <= maxz; ++z)
 	{
@@ -2079,10 +2079,10 @@ dtStatus dtMarkBoxArea(dtTileCacheLayer& layer, const float* orig, const float c
 		{			
 			float x2 = 2.0f*(float(x) - cx);
 			float z2 = 2.0f*(float(z) - cz);
-			float xrot = rotaux[1]*x2 + rotaux[0]*z2;
+			float xrot = rotAux[1]*x2 + rotAux[0]*z2;
 			if (xrot > xhalf || xrot < -xhalf)
 				continue;
-			float zrot = rotaux[1]*z2 - rotaux[0]*x2;
+			float zrot = rotAux[1]*z2 - rotAux[0]*x2;
 			if (zrot > zhalf || zrot < -zhalf)
 				continue;
 			const int y = layer.heights[x+z*w];

--- a/DetourTileCache/Source/DetourTileCacheBuilder.cpp
+++ b/DetourTileCache/Source/DetourTileCacheBuilder.cpp
@@ -2042,7 +2042,7 @@ dtStatus dtMarkBoxArea(dtTileCacheLayer& layer, const float* orig, const float c
 }
 
 dtStatus dtMarkBoxArea(dtTileCacheLayer& layer, const float* orig, const float cs, const float ch,
-					   const float* center, const float* halfExtents, const float* rotAux, const unsigned char areaId)
+					   const float* center, const float* extents, const float* rotAux, const unsigned char areaId)
 {
 	const int w = (int)layer.header->width;
 	const int h = (int)layer.header->height;
@@ -2052,13 +2052,13 @@ dtStatus dtMarkBoxArea(dtTileCacheLayer& layer, const float* orig, const float c
 	float cx = (center[0] - orig[0])*ics;
 	float cz = (center[2] - orig[2])*ics;
 	
-	float maxr = 1.41f*dtMax(halfExtents[0], halfExtents[2]);
+	float maxr = 1.41f*dtMax(extents[0], extents[2]);
 	int minx = (int)floorf(cx - maxr*ics);
 	int maxx = (int)floorf(cx + maxr*ics);
 	int minz = (int)floorf(cz - maxr*ics);
 	int maxz = (int)floorf(cz + maxr*ics);
-	int miny = (int)floorf((center[1]-halfExtents[1]-orig[1])*ich);
-	int maxy = (int)floorf((center[1]+halfExtents[1]-orig[1])*ich);
+	int miny = (int)floorf((center[1]-extents[1]-orig[1])*ich);
+	int maxy = (int)floorf((center[1]+extents[1]-orig[1])*ich);
 
 	if (maxx < 0) return DT_SUCCESS;
 	if (minx >= w) return DT_SUCCESS;
@@ -2070,8 +2070,8 @@ dtStatus dtMarkBoxArea(dtTileCacheLayer& layer, const float* orig, const float c
 	if (minz < 0) minz = 0;
 	if (maxz >= h) maxz = h-1;
 	
-	float xhalf = halfExtents[0]*ics + 0.5f;
-	float zhalf = halfExtents[2]*ics + 0.5f;
+	float xhalf = extents[0]*ics + 0.5f;
+	float zhalf = extents[2]*ics + 0.5f;
 
 	for (int z = minz; z <= maxz; ++z)
 	{

--- a/DetourTileCache/Source/DetourTileCacheBuilder.cpp
+++ b/DetourTileCache/Source/DetourTileCacheBuilder.cpp
@@ -2041,6 +2041,60 @@ dtStatus dtMarkBoxArea(dtTileCacheLayer& layer, const float* orig, const float c
 	return DT_SUCCESS;
 }
 
+dtStatus dtMarkBoxArea(dtTileCacheLayer& layer, const float* orig, const float cs, const float ch,
+					   const float* center, const float* halfextents, const float* rotaux, const unsigned char areaId)
+{
+	const int w = (int)layer.header->width;
+	const int h = (int)layer.header->height;
+	const float ics = 1.0f/cs;
+	const float ich = 1.0f/ch;
+
+	float cx = (center[0] - orig[0])*ics;
+	float cz = (center[2] - orig[2])*ics;
+	
+	float maxr = 1.41f*dtMax(halfextents[0], halfextents[2]);
+	int minx = (int)floorf(cx - maxr*ics);
+	int maxx = (int)floorf(cx + maxr*ics);
+	int minz = (int)floorf(cz - maxr*ics);
+	int maxz = (int)floorf(cz + maxr*ics);
+	int miny = (int)floorf((center[1]-halfextents[1]-orig[1])*ich);
+	int maxy = (int)floorf((center[1]+halfextents[1]-orig[1])*ich);
+
+	if (maxx < 0) return DT_SUCCESS;
+	if (minx >= w) return DT_SUCCESS;
+	if (maxz < 0) return DT_SUCCESS;
+	if (minz >= h) return DT_SUCCESS;
+
+	if (minx < 0) minx = 0;
+	if (maxx >= w) maxx = w-1;
+	if (minz < 0) minz = 0;
+	if (maxz >= h) maxz = h-1;
+	
+	float xhalf = halfextents[0]*ics + 0.5f;
+	float zhalf = halfextents[2]*ics + 0.5f;
+
+	for (int z = minz; z <= maxz; ++z)
+	{
+		for (int x = minx; x <= maxx; ++x)
+		{			
+			float x2 = 2.0f*(float(x) - cx);
+			float z2 = 2.0f*(float(z) - cz);
+			float xrot = rotaux[1]*x2 + rotaux[0]*z2;
+			if (xrot > xhalf || xrot < -xhalf)
+				continue;
+			float zrot = rotaux[1]*z2 - rotaux[0]*x2;
+			if (zrot > zhalf || zrot < -zhalf)
+				continue;
+			const int y = layer.heights[x+z*w];
+			if (y < miny || y > maxy)
+				continue;
+			layer.areas[x+z*w] = areaId;
+		}
+	}
+
+	return DT_SUCCESS;
+}
+
 dtStatus dtBuildTileCacheLayer(dtTileCacheCompressor* comp,
 							   dtTileCacheLayerHeader* header,
 							   const unsigned char* heights,


### PR DESCRIPTION
Added option to add rotated Box obstacle to TileCache (without messing with the existing box).

Very useful when you have a obstacle with a big difference in x to z ratio and that could be rotated (not aligned), like a wall.