### PR TITLE
Bump up RC_SPAN_HEIGHT_BITS.

### DIFF
--- a/Recast/Include/Recast.h
+++ b/Recast/Include/Recast.h
@@ -263,7 +263,7 @@ struct rcConfig
 };
 
 /// Defines the number of bits allocated to rcSpan::smin and rcSpan::smax.
-static const int RC_SPAN_HEIGHT_BITS = 13;
+static const int RC_SPAN_HEIGHT_BITS = 16;
 /// Defines the maximum value for rcSpan::smin and rcSpan::smax.
 static const int RC_SPAN_MAX_HEIGHT = (1 << RC_SPAN_HEIGHT_BITS) - 1;
 
@@ -277,7 +277,7 @@ struct rcSpan
 {
 	unsigned int smin : RC_SPAN_HEIGHT_BITS; ///< The lower limit of the span. [Limit: < #smax]
 	unsigned int smax : RC_SPAN_HEIGHT_BITS; ///< The upper limit of the span. [Limit: <= #RC_SPAN_MAX_HEIGHT]
-	unsigned int area : 6;                   ///< The area id assigned to the span.
+	unsigned int area : 8;                   ///< The area id assigned to the span.
 	rcSpan* next;                            ///< The next span higher up in column.
 };
 

--- a/Recast/Include/Recast.h
+++ b/Recast/Include/Recast.h
@@ -277,7 +277,7 @@ struct rcSpan
 {
 	unsigned int smin : RC_SPAN_HEIGHT_BITS; ///< The lower limit of the span. [Limit: < #smax]
 	unsigned int smax : RC_SPAN_HEIGHT_BITS; ///< The upper limit of the span. [Limit: <= #RC_SPAN_MAX_HEIGHT]
-	unsigned int area : 8;                   ///< The area id assigned to the span.
+	unsigned int area : 6;                   ///< The area id assigned to the span.
 	rcSpan* next;                            ///< The next span higher up in column.
 };
 


### PR DESCRIPTION
This does not affect the size of rcSpan on x64, and makes it less likely users will need to modify this.