### PR TITLE
fixed load .gset file error

### DIFF
--- a/RecastDemo/Source/Filelist.cpp
+++ b/RecastDemo/Source/Filelist.cpp
@@ -55,10 +55,11 @@ void scanDirectoryAppend(const string& path, const string& ext, vector<string>& 
 		return;
 	}
 	
+	int extLen = strlen(ext.c_str());
 	while ((current = readdir(dp)) != 0)
 	{
 		int len = strlen(current->d_name);
-		if (len > 4 && strncmp(current->d_name + len - 4, ext.c_str(), 4) == 0)
+		if (len > extLen && strncmp(current->d_name + len - extLen, ext.c_str(), extLen) == 0)
 		{
 			filelist.push_back(current->d_name);
 		}


### PR DESCRIPTION
The previous code can not read the .gset file, because of strlen(.gset) > 4 . when strlen(ext) > 4 strncmp(current->d_name + len - 4, ext.c_str(), 4) == 0 is aways false 