### PR TITLE
Provide better feedback when dtNavMesh::addTile fails due to a tile already being present at a given x,y

### DIFF
--- a/Detour/Include/DetourStatus.h
+++ b/Detour/Include/DetourStatus.h
@@ -35,6 +35,7 @@ static const unsigned int DT_INVALID_PARAM = 1 << 3;	// An input parameter was i
 static const unsigned int DT_BUFFER_TOO_SMALL = 1 << 4;	// Result buffer for the query was too small to store all results.
 static const unsigned int DT_OUT_OF_NODES = 1 << 5;		// Query ran out of nodes during search.
 static const unsigned int DT_PARTIAL_RESULT = 1 << 6;	// Query did not reach the end location, returning best guess. 
+static const unsigned int DT_ALREADY_OCCUPIED = 1 << 7;	// A tile has already been assigned to the given x,y coordinate
 
 
 // Returns true of status is success.

--- a/Detour/Source/DetourNavMesh.cpp
+++ b/Detour/Source/DetourNavMesh.cpp
@@ -855,7 +855,7 @@ dtStatus dtNavMesh::addTile(unsigned char* data, int dataSize, int flags,
 		
 	// Make sure the location is free.
 	if (getTileAt(header->x, header->y, header->layer))
-		return DT_FAILURE;
+		return DT_FAILURE | DT_ALREADY_OCCUPIED;
 		
 	// Allocate a tile.
 	dtMeshTile* tile = 0;


### PR DESCRIPTION
  Failure because the tile coordinate is already occupied is the only failure that does not specify more information.