### PR TITLE
Remove redundant copying in rcBuildRegions.

### DIFF
--- a/Recast/Include/RecastAlloc.h
+++ b/Recast/Include/RecastAlloc.h
@@ -20,6 +20,7 @@
 #define RECASTALLOC_H
 
 #include <stddef.h>
+#include <vector>
 
 /// Provides hint values to the memory allocator on how long the
 /// memory is expected to be used.
@@ -58,64 +59,59 @@ void* rcAlloc(size_t size, rcAllocHint hint);
 /// @see rcAlloc
 void rcFree(void* ptr);
 
+// An STL Allocator that uses rcAlloc and rcFree
+template <typename T, rcAllocHint Hint>
+struct rcAllocator {
+	using value_type = T;
+	T* allocate(std::size_t count, T* hint = nullptr) {
+		if (count > std::size_t(-1) / sizeof(T)) { throw std::bad_alloc(); }
+		T* value = static_cast<T*>(rcAlloc(count * sizeof(T), Hint));
+		if (!value) { throw std::bad_alloc(); }
+		return value;
+	}
+	void deallocate(T* p, std::size_t count) {
+		rcFree(static_cast<void*>(p));
+	}
+	template <typename U>
+	struct rebind {
+		using other = rcAllocator<U, Hint>;
+	};
 
-/// A simple dynamic array of integers.
-class rcIntArray
+	template <typename U, rcAllocHint H>
+	bool operator==(const rcAllocator<U, H>&) { return true; }
+	template <typename U, rcAllocHint H>
+	bool operator!=(const rcAllocator<U, H>&) { return false; }
+};
+
+// Aliases for std::vector which default to rcAllocator.
+template <typename T, typename Allocator = rcAllocator<T, RC_ALLOC_TEMP>>
+using rcVector = std::vector<T, Allocator>;
+template <typename T, typename Allocator = rcAllocator<T, RC_ALLOC_PERM>>
+using rcPermVector = std::vector<T, Allocator>;
+
+// Legacy custom vector. New code should use rcVector<int> directly.
+class rcIntArray : public rcVector<int>
 {
-	int* m_data;
-	int m_size, m_cap;
-
-	void doResize(int n);
-	
-	// Explicitly disabled copy constructor and copy assignment operator.
-	rcIntArray(const rcIntArray&);
-	rcIntArray& operator=(const rcIntArray&);
-
 public:
 	/// Constructs an instance with an initial array size of zero.
-	rcIntArray() : m_data(0), m_size(0), m_cap(0) {}
+	rcIntArray() {}
 
 	/// Constructs an instance initialized to the specified size.
 	///  @param[in]		n	The initial size of the integer array.
-	rcIntArray(int n) : m_data(0), m_size(0), m_cap(0) { resize(n); }
-	~rcIntArray() { rcFree(m_data); }
-
-	/// Specifies the new size of the integer array.
-	///  @param[in]		n	The new size of the integer array.
-	void resize(int n)
-	{
-		if (n > m_cap)
-			doResize(n);
-		
-		m_size = n;
-	}
+	rcIntArray(int n) { resize(n); }
 
 	/// Push the specified integer onto the end of the array and increases the size by one.
 	///  @param[in]		item	The new value.
-	void push(int item) { resize(m_size+1); m_data[m_size-1] = item; }
+	void push(int item) { push_back(item); }
 
 	/// Returns the value at the end of the array and reduces the size by one.
 	///  @return The value at the end of the array.
 	int pop()
 	{
-		if (m_size > 0)
-			m_size--;
-		
-		return m_data[m_size];
+		int value = back();
+		pop_back();
+		return value;
 	}
-
-	/// The value at the specified array index.
-	/// @warning Does not provide overflow protection.
-	///  @param[in]		i	The index of the value.
-	const int& operator[](int i) const { return m_data[i]; }
-
-	/// The value at the specified array index.
-	/// @warning Does not provide overflow protection.
-	///  @param[in]		i	The index of the value.
-	int& operator[](int i) { return m_data[i]; }
-
-	/// The current size of the integer array.
-	int size() const { return m_size; }
 };
 
 /// A simple helper class used to delete an array when it goes out of scope.

--- a/Recast/Source/RecastAlloc.cpp
+++ b/Recast/Source/RecastAlloc.cpp
@@ -58,29 +58,3 @@ void rcFree(void* ptr)
 	if (ptr)
 		sRecastFreeFunc(ptr);
 }
-
-/// @class rcIntArray
-///
-/// While it is possible to pre-allocate a specific array size during 
-/// construction or by using the #resize method, certain methods will 
-/// automatically resize the array as needed.
-///
-/// @warning The array memory is not initialized to zero when the size is 
-/// manually set during construction or when using #resize.
-
-/// @par
-///
-/// Using this method ensures the array is at least large enough to hold
-/// the specified number of elements.  This can improve performance by
-/// avoiding auto-resizing during use.
-void rcIntArray::doResize(int n)
-{
-	if (!m_cap) m_cap = n;
-	while (m_cap < n) m_cap *= 2;
-	int* newData = (int*)rcAlloc(m_cap*sizeof(int), RC_ALLOC_TEMP);
-	rcAssert(newData);
-	if (m_size && newData) memcpy(newData, m_data, m_size*sizeof(int));
-	rcFree(m_data);
-	m_data = newData;
-}
-

--- a/Recast/Source/RecastRegion.cpp
+++ b/Recast/Source/RecastRegion.cpp
@@ -385,13 +385,14 @@ static unsigned short* expandRegions(int maxIter, unsigned short level,
 		}
 	}
 
+	rcIntArray dirtyEntries;
+	memcpy(dstReg, srcReg, sizeof(unsigned short)*chf.spanCount);
+	memcpy(dstDist, srcDist, sizeof(unsigned short)*chf.spanCount);
 	int iter = 0;
 	while (stack.size() > 0)
 	{
 		int failed = 0;
-		
-		memcpy(dstReg, srcReg, sizeof(unsigned short)*chf.spanCount);
-		memcpy(dstDist, srcDist, sizeof(unsigned short)*chf.spanCount);
+		dirtyEntries.resize(0);
 		
 		for (int j = 0; j < stack.size(); j += 3)
 		{
@@ -429,6 +430,7 @@ static unsigned short* expandRegions(int maxIter, unsigned short level,
 				stack[j+2] = -1; // mark as used
 				dstReg[i] = r;
 				dstDist[i] = d2;
+				dirtyEntries.push(i);
 			}
 			else
 			{
@@ -448,6 +450,14 @@ static unsigned short* expandRegions(int maxIter, unsigned short level,
 			++iter;
 			if (iter >= maxIter)
 				break;
+		}
+
+		// If doing another iteration, copy entries that differ between
+		// src and dst.
+		for (int i = 0; i < dirtyEntries.size(); i++) {
+			int entry = dirtyEntries[i];
+			dstReg[entry] = srcReg[entry];
+			dstDist[entry] = srcDist[entry];
 		}
 	}
 	

--- a/Recast/Source/RecastRegion.cpp
+++ b/Recast/Source/RecastRegion.cpp
@@ -385,12 +385,12 @@ static unsigned short* expandRegions(int maxIter, unsigned short level,
 		}
 	}
 
-	rcIntArray dirtyEntries;
+	rcVector<int> dirtyEntries;
 	int iter = 0;
 	while (stack.size() > 0)
 	{
 		int failed = 0;
-		dirtyEntries.resize(0);
+		dirtyEntries.clear();
 		
 		for (int j = 0; j < stack.size(); j += 3)
 		{
@@ -428,7 +428,7 @@ static unsigned short* expandRegions(int maxIter, unsigned short level,
 				stack[j+2] = -1; // mark as used
 				dstReg[i] = r;
 				dstDist[i] = d2;
-				dirtyEntries.push(i);
+				dirtyEntries.push_back(i);
 			}
 			else
 			{
@@ -441,8 +441,7 @@ static unsigned short* expandRegions(int maxIter, unsigned short level,
 		rcSwap(srcDist, dstDist);
 
 		// Copy entries that differ between src and dst to keep them in sync.
-		for (int i = 0; i < dirtyEntries.size(); i++) {
-			int entry = dirtyEntries[i];
+		for (int entry : dirtyEntries) {
 			dstReg[entry] = srcReg[entry];
 			dstDist[entry] = srcDist[entry];
 		}

--- a/Recast/Source/RecastRegion.cpp
+++ b/Recast/Source/RecastRegion.cpp
@@ -240,22 +240,26 @@ static unsigned short* boxBlur(rcCompactHeightfield& chf, int thr,
 	return dst;
 }
 
+struct SpanLocator {
+	int x;
+	int y;
+	// index within chf.spans
+	int i;
+};
 
 static bool floodRegion(int x, int y, int i,
 						unsigned short level, unsigned short r,
 						rcCompactHeightfield& chf,
 						unsigned short* srcReg, unsigned short* srcDist,
-						rcIntArray& stack)
+						rcVector<SpanLocator>& stack)
 {
 	const int w = chf.width;
 	
 	const unsigned char area = chf.areas[i];
 	
 	// Flood fill mark region.
-	stack.resize(0);
-	stack.push((int)x);
-	stack.push((int)y);
-	stack.push((int)i);
+	stack.clear();
+	stack.push_back({x, y, i});
 	srcReg[i] = r;
 	srcDist[i] = 0;
 	
@@ -264,11 +268,10 @@ static bool floodRegion(int x, int y, int i,
 	
 	while (stack.size() > 0)
 	{
-		int ci = stack.pop();
-		int cy = stack.pop();
-		int cx = stack.pop();
+		SpanLocator current = stack.back();
+		stack.pop_back();
 		
-		const rcCompactSpan& cs = chf.spans[ci];
+		const rcCompactSpan& cs = chf.spans[current.i];
 		
 		// Check if any of the neighbours already have a valid region set.
 		unsigned short ar = 0;
@@ -277,8 +280,8 @@ static bool floodRegion(int x, int y, int i,
 			// 8 connected
 			if (rcGetCon(cs, dir) != RC_NOT_CONNECTED)
 			{
-				const int ax = cx + rcGetDirOffsetX(dir);
-				const int ay = cy + rcGetDirOffsetY(dir);
+				const int ax = current.x + rcGetDirOffsetX(dir);
+				const int ay = current.y + rcGetDirOffsetY(dir);
 				const int ai = (int)chf.cells[ax+ay*w].index + rcGetCon(cs, dir);
 				if (chf.areas[ai] != area)
 					continue;
@@ -312,7 +315,7 @@ static bool floodRegion(int x, int y, int i,
 		}
 		if (ar != 0)
 		{
-			srcReg[ci] = 0;
+			srcReg[current.i] = 0;
 			continue;
 		}
 		
@@ -323,8 +326,8 @@ static bool floodRegion(int x, int y, int i,
 		{
 			if (rcGetCon(cs, dir) != RC_NOT_CONNECTED)
 			{
-				const int ax = cx + rcGetDirOffsetX(dir);
-				const int ay = cy + rcGetDirOffsetY(dir);
+				const int ax = current.x + rcGetDirOffsetX(dir);
+				const int ay = current.y + rcGetDirOffsetY(dir);
 				const int ai = (int)chf.cells[ax+ay*w].index + rcGetCon(cs, dir);
 				if (chf.areas[ai] != area)
 					continue;
@@ -332,9 +335,7 @@ static bool floodRegion(int x, int y, int i,
 				{
 					srcReg[ai] = r;
 					srcDist[ai] = 0;
-					stack.push(ax);
-					stack.push(ay);
-					stack.push(ai);
+					stack.push_back({ax, ay, ai});
 				}
 			}
 		}
@@ -347,7 +348,7 @@ static unsigned short* expandRegions(int maxIter, unsigned short level,
 									 rcCompactHeightfield& chf,
 									 unsigned short* srcReg, unsigned short* srcDist,
 									 unsigned short* dstReg, unsigned short* dstDist, 
-									 rcIntArray& stack,
+									 rcVector<SpanLocator>& stack,
 									 bool fillStack)
 {
 	const int w = chf.width;
@@ -356,7 +357,7 @@ static unsigned short* expandRegions(int maxIter, unsigned short level,
 	if (fillStack)
 	{
 		// Find cells revealed by the raised level.
-		stack.resize(0);
+		stack.clear();
 		for (int y = 0; y < h; ++y)
 		{
 			for (int x = 0; x < w; ++x)
@@ -366,9 +367,7 @@ static unsigned short* expandRegions(int maxIter, unsigned short level,
 				{
 					if (chf.dist[i] >= level && srcReg[i] == 0 && chf.areas[i] != RC_NULL_AREA)
 					{
-						stack.push(x);
-						stack.push(y);
-						stack.push(i);
+						stack.push_back({x, y, i});
 					}
 				}
 			}
@@ -377,11 +376,10 @@ static unsigned short* expandRegions(int maxIter, unsigned short level,
 	else // use cells in the input stack
 	{
 		// mark all cells which already have a region
-		for (int j=0; j<stack.size(); j+=3)
+		for (SpanLocator& span : stack)
 		{
-			int i = stack[j+2];
-			if (srcReg[i] != 0)
-				stack[j+2] = -1;
+			if (srcReg[span.i] != 0)
+				span.i = -1;
 		}
 	}
 
@@ -392,11 +390,11 @@ static unsigned short* expandRegions(int maxIter, unsigned short level,
 		int failed = 0;
 		dirtyEntries.clear();
 		
-		for (int j = 0; j < stack.size(); j += 3)
+		for (SpanLocator& span : stack)
 		{
-			int x = stack[j+0];
-			int y = stack[j+1];
-			int i = stack[j+2];
+			int x = span.x;
+			int y = span.y;
+			int i = span.i;
 			if (i < 0)
 			{
 				failed++;
@@ -425,7 +423,7 @@ static unsigned short* expandRegions(int maxIter, unsigned short level,
 			}
 			if (r)
 			{
-				stack[j+2] = -1; // mark as used
+				span.i = -1; // mark as used
 				dstReg[i] = r;
 				dstDist[i] = d2;
 				dirtyEntries.push_back(i);
@@ -446,7 +444,7 @@ static unsigned short* expandRegions(int maxIter, unsigned short level,
 			dstDist[entry] = srcDist[entry];
 		}
 		
-		if (failed*3 == stack.size())
+		if (failed == stack.size())
 			break;
 		
 		if (level > 0)
@@ -465,7 +463,7 @@ static unsigned short* expandRegions(int maxIter, unsigned short level,
 static void sortCellsByLevel(unsigned short startLevel,
 							  rcCompactHeightfield& chf,
 							  const unsigned short* srcReg,
-							  unsigned int nbStacks, rcIntArray* stacks,
+							  unsigned int nbStacks, rcVector<SpanLocator>* stacks,
 							  unsigned short loglevelsPerStack) // the levels per stack (2 in our case) as a bit shift
 {
 	const int w = chf.width;
@@ -473,7 +471,7 @@ static void sortCellsByLevel(unsigned short startLevel,
 	startLevel = startLevel >> loglevelsPerStack;
 
 	for (unsigned int j=0; j<nbStacks; ++j)
-		stacks[j].resize(0);
+		stacks[j].clear();
 
 	// put all cells in the level range into the appropriate stacks
 	for (int y = 0; y < h; ++y)
@@ -493,26 +491,21 @@ static void sortCellsByLevel(unsigned short startLevel,
 				if (sId < 0)
 					sId = 0;
 
-				stacks[sId].push(x);
-				stacks[sId].push(y);
-				stacks[sId].push(i);
+				stacks[sId].push_back({x, y, i});
 			}
 		}
 	}
 }
 
 
-static void appendStacks(rcIntArray& srcStack, rcIntArray& dstStack,
+static void appendStacks(rcVector<SpanLocator>& srcStack, rcVector<SpanLocator>& dstStack,
 						 const unsigned short* srcReg)
 {
-	for (int j=0; j<srcStack.size(); j+=3)
+	for (const SpanLocator& span : srcStack)
 	{
-		int i = srcStack[j+2];
-		if ((i < 0) || (srcReg[i] != 0))
+		if ((span.i < 0) || (srcReg[span.i] != 0))
 			continue;
-		dstStack.push(srcStack[j]);
-		dstStack.push(srcStack[j+1]);
-		dstStack.push(srcStack[j+2]);
+		dstStack.push_back(span);
 	}
 }
 
@@ -1541,32 +1534,24 @@ bool rcBuildRegions(rcContext* ctx, rcCompactHeightfield& chf,
 	const int w = chf.width;
 	const int h = chf.height;
 	
-	rcScopedDelete<unsigned short> buf((unsigned short*)rcAlloc(sizeof(unsigned short)*chf.spanCount*4, RC_ALLOC_TEMP));
-	if (!buf)
-	{
-		ctx->log(RC_LOG_ERROR, "rcBuildRegions: Out of memory 'tmp' (%d).", chf.spanCount*4);
-		return false;
-	}
+	rcVector<unsigned short> buf(chf.spanCount*4, 0);
 	
 	ctx->startTimer(RC_TIMER_BUILD_REGIONS_WATERSHED);
 
 	const int LOG_NB_STACKS = 3;
 	const int NB_STACKS = 1 << LOG_NB_STACKS;
-	rcIntArray lvlStacks[NB_STACKS];
+	rcVector<SpanLocator> lvlStacks[NB_STACKS];
 	for (int i=0; i<NB_STACKS; ++i)
-		lvlStacks[i].resize(1024);
+		lvlStacks[i].reserve(1024 / sizeof(SpanLocator));
 
-	rcIntArray stack(1024);
+	rcVector<SpanLocator> stack;
+	stack.reserve(1024 / sizeof(SpanLocator));
 	rcIntArray visited(1024);
 	
-	unsigned short* srcReg = buf;
-	unsigned short* srcDist = buf+chf.spanCount;
-	unsigned short* dstReg = buf+chf.spanCount*2;
-	unsigned short* dstDist = buf+chf.spanCount*3;
-	
-	memset(srcReg, 0, sizeof(unsigned short)*chf.spanCount);
-	memset(srcDist, 0, sizeof(unsigned short)*chf.spanCount);
-	memset(dstDist, 0, sizeof(unsigned short)*chf.spanCount);
+	unsigned short* srcReg = buf.data();
+	unsigned short* srcDist = buf.data()+chf.spanCount;
+	unsigned short* dstReg = buf.data()+chf.spanCount*2;
+	unsigned short* dstDist = buf.data()+chf.spanCount*3;
 	
 	unsigned short regionId = 1;
 	unsigned short level = (chf.maxDistance+1) & ~1;
@@ -1625,11 +1610,11 @@ bool rcBuildRegions(rcContext* ctx, rcCompactHeightfield& chf,
 			rcScopedTimer timerFloor(ctx, RC_TIMER_BUILD_REGIONS_FLOOD);
 
 			// Mark new regions with IDs.
-			for (int j = 0; j<lvlStacks[sId].size(); j += 3)
+			for (const SpanLocator& span : lvlStacks[sId])
 			{
-				int x = lvlStacks[sId][j];
-				int y = lvlStacks[sId][j+1];
-				int i = lvlStacks[sId][j+2];
+				int x = span.x;
+				int y = span.y;
+				int i = span.i;
 				if (i >= 0 && srcReg[i] == 0)
 				{
 	                                // These two calls should have the same results.


### PR DESCRIPTION
rcBuildRegions uses dstReg and dstDist as scratch space. Currently, it copies src* -> dst* on each iteration of the inner loop of expandRegions. This is a costly operation; on a sampled map, it copies 16Mbytes of data, when only ~6kbytes are accessed. We modify rcBuildRegions and expandRegions to keep src* and dst* in sync, except during the main loop of expandRegions.

This has reduced runtime of the Recast portion of my build pipeline by 70% (!). memcpy() no longer appears in sampled profiles at all.