### PR TITLE
Remove redundant copying in rcBuildRegions.

### DIFF
--- a/Recast/Source/RecastRegion.cpp
+++ b/Recast/Source/RecastRegion.cpp
@@ -438,8 +438,8 @@ static void expandRegions(int maxIter, unsigned short level,
 		// Copy entries that differ between src and dst to keep them in sync.
 		for (int i = 0; i < dirtyEntries.size(); i+=3) {
 			int idx = dirtyEntries[i];
-			srcReg[idx] = dirtyEntries[i+1];
-			srcDist[idx] = dirtyEntries[i+2];
+			srcReg[idx] = (unsigned short)dirtyEntries[i+1];
+			srcDist[idx] = (unsigned short)dirtyEntries[i+2];
 		}
 		
 		if (failed*3 == stack.size())

--- a/Recast/Source/RecastRegion.cpp
+++ b/Recast/Source/RecastRegion.cpp
@@ -385,13 +385,14 @@ static unsigned short* expandRegions(int maxIter, unsigned short level,
 		}
 	}
 
+	rcIntArray dirtyEntries;
+	memcpy(dstReg, srcReg, sizeof(unsigned short)*chf.spanCount);
+	memcpy(dstDist, srcDist, sizeof(unsigned short)*chf.spanCount);
 	int iter = 0;
 	while (stack.size() > 0)
 	{
 		int failed = 0;
-		
-		memcpy(dstReg, srcReg, sizeof(unsigned short)*chf.spanCount);
-		memcpy(dstDist, srcDist, sizeof(unsigned short)*chf.spanCount);
+		dirtyEntries.resize(0);
 		
 		for (int j = 0; j < stack.size(); j += 3)
 		{
@@ -429,6 +430,7 @@ static unsigned short* expandRegions(int maxIter, unsigned short level,
 				stack[j+2] = -1; // mark as used
 				dstReg[i] = r;
 				dstDist[i] = d2;
+				dirtyEntries.push(i);
 			}
 			else
 			{
@@ -448,6 +450,14 @@ static unsigned short* expandRegions(int maxIter, unsigned short level,
 			++iter;
 			if (iter >= maxIter)
 				break;
+		}
+
+		// If doing another iteration, copy entries that differ between
+		// src and dst.
+		for (int i = 0; i < dirtyEntries.size(); i++) {
+			int entry = dirtyEntries[i];
+			dstReg[entry] = srcReg[entry];
+			dstDist[entry] = srcDist[entry];
 		}
 	}
 	


### PR DESCRIPTION
rcBuildRegions uses dstReg and dstDist as scratch space. Currently, it copies src* -> dst* on each iteration of the inner loop of expandRegions. This is a costly operation; on a sampled map, it copies 16Mbytes of data, when only ~6kbytes are accessed. We get rid of dst*, and modify expandRegions to keep track of deltas and apply them at the end of each iteration.

This has reduced runtime of the Recast portion of my build pipeline by 70% (!). memcpy() no longer appears in sampled profiles at all.