### PR TITLE
Add support for std::vector in Recast, and convert apply to a few use cases.

### DIFF
--- a/Recast/Include/RecastAlloc.h
+++ b/Recast/Include/RecastAlloc.h
@@ -20,6 +20,7 @@
 #define RECASTALLOC_H
 
 #include <stddef.h>
+#include <vector>
 
 /// Provides hint values to the memory allocator on how long the
 /// memory is expected to be used.
@@ -58,64 +59,59 @@ void* rcAlloc(size_t size, rcAllocHint hint);
 /// @see rcAlloc
 void rcFree(void* ptr);
 
+// An STL Allocator that uses rcAlloc and rcFree
+template <typename T, rcAllocHint Hint>
+struct rcAllocator {
+	using value_type = T;
+	T* allocate(std::size_t count, T* hint = nullptr) {
+		if (count > std::size_t(-1) / sizeof(T)) { throw std::bad_alloc(); }
+		T* value = static_cast<T*>(rcAlloc(count * sizeof(T), Hint));
+		if (!value) { throw std::bad_alloc(); }
+		return value;
+	}
+	void deallocate(T* p, std::size_t count) {
+		rcFree(static_cast<void*>(p));
+	}
+	template <typename U>
+	struct rebind {
+		using other = rcAllocator<U, Hint>;
+	};
 
-/// A simple dynamic array of integers.
-class rcIntArray
+	template <typename U, rcAllocHint H>
+	bool operator==(const rcAllocator<U, H>&) { return true; }
+	template <typename U, rcAllocHint H>
+	bool operator!=(const rcAllocator<U, H>&) { return false; }
+};
+
+// Aliases for std::vector which default to rcAllocator.
+template <typename T, typename Allocator = rcAllocator<T, RC_ALLOC_TEMP>>
+using rcVector = std::vector<T, Allocator>;
+template <typename T, typename Allocator = rcAllocator<T, RC_ALLOC_PERM>>
+using rcPermVector = std::vector<T, Allocator>;
+
+// Legacy custom vector. New code should use rcVector<int> directly.
+class rcIntArray : public rcVector<int>
 {
-	int* m_data;
-	int m_size, m_cap;
-
-	void doResize(int n);
-	
-	// Explicitly disabled copy constructor and copy assignment operator.
-	rcIntArray(const rcIntArray&);
-	rcIntArray& operator=(const rcIntArray&);
-
 public:
 	/// Constructs an instance with an initial array size of zero.
-	rcIntArray() : m_data(0), m_size(0), m_cap(0) {}
+	rcIntArray() {}
 
 	/// Constructs an instance initialized to the specified size.
 	///  @param[in]		n	The initial size of the integer array.
-	rcIntArray(int n) : m_data(0), m_size(0), m_cap(0) { resize(n); }
-	~rcIntArray() { rcFree(m_data); }
-
-	/// Specifies the new size of the integer array.
-	///  @param[in]		n	The new size of the integer array.
-	void resize(int n)
-	{
-		if (n > m_cap)
-			doResize(n);
-		
-		m_size = n;
-	}
+	rcIntArray(int n) { resize(n); }
 
 	/// Push the specified integer onto the end of the array and increases the size by one.
 	///  @param[in]		item	The new value.
-	void push(int item) { resize(m_size+1); m_data[m_size-1] = item; }
+	void push(int item) { push_back(item); }
 
 	/// Returns the value at the end of the array and reduces the size by one.
 	///  @return The value at the end of the array.
 	int pop()
 	{
-		if (m_size > 0)
-			m_size--;
-		
-		return m_data[m_size];
+		int value = back();
+		pop_back();
+		return value;
 	}
-
-	/// The value at the specified array index.
-	/// @warning Does not provide overflow protection.
-	///  @param[in]		i	The index of the value.
-	const int& operator[](int i) const { return m_data[i]; }
-
-	/// The value at the specified array index.
-	/// @warning Does not provide overflow protection.
-	///  @param[in]		i	The index of the value.
-	int& operator[](int i) { return m_data[i]; }
-
-	/// The current size of the integer array.
-	int size() const { return m_size; }
 };
 
 /// A simple helper class used to delete an array when it goes out of scope.

--- a/Recast/Source/RecastAlloc.cpp
+++ b/Recast/Source/RecastAlloc.cpp
@@ -58,29 +58,3 @@ void rcFree(void* ptr)
 	if (ptr)
 		sRecastFreeFunc(ptr);
 }
-
-/// @class rcIntArray
-///
-/// While it is possible to pre-allocate a specific array size during 
-/// construction or by using the #resize method, certain methods will 
-/// automatically resize the array as needed.
-///
-/// @warning The array memory is not initialized to zero when the size is 
-/// manually set during construction or when using #resize.
-
-/// @par
-///
-/// Using this method ensures the array is at least large enough to hold
-/// the specified number of elements.  This can improve performance by
-/// avoiding auto-resizing during use.
-void rcIntArray::doResize(int n)
-{
-	if (!m_cap) m_cap = n;
-	while (m_cap < n) m_cap *= 2;
-	int* newData = (int*)rcAlloc(m_cap*sizeof(int), RC_ALLOC_TEMP);
-	rcAssert(newData);
-	if (m_size && newData) memcpy(newData, m_data, m_size*sizeof(int));
-	rcFree(m_data);
-	m_data = newData;
-}
-

--- a/Recast/Source/RecastRegion.cpp
+++ b/Recast/Source/RecastRegion.cpp
@@ -384,12 +384,17 @@ static void expandRegions(int maxIter, unsigned short level,
 		}
 	}
 
-	rcIntArray dirtyEntries;
+	struct DirtyEntry {
+	  int index;
+	  unsigned short region;
+	  unsigned short d2;
+	};
+	rcVector<DirtyEntry> dirtyEntries;
 	int iter = 0;
 	while (stack.size() > 0)
 	{
 		int failed = 0;
-		dirtyEntries.resize(0);
+		dirtyEntries.clear();
 		
 		for (int j = 0; j < stack.size(); j += 3)
 		{
@@ -425,9 +430,7 @@ static void expandRegions(int maxIter, unsigned short level,
 			if (r)
 			{
 				stack[j+2] = -1; // mark as used
-				dirtyEntries.push(i);
-				dirtyEntries.push(r);
-				dirtyEntries.push(d2);
+				dirtyEntries.push_back({i, r, d2});
 			}
 			else
 			{
@@ -436,10 +439,10 @@ static void expandRegions(int maxIter, unsigned short level,
 		}
 		
 		// Copy entries that differ between src and dst to keep them in sync.
-		for (int i = 0; i < dirtyEntries.size(); i+=3) {
-			int idx = dirtyEntries[i];
-			srcReg[idx] = (unsigned short)dirtyEntries[i+1];
-			srcDist[idx] = (unsigned short)dirtyEntries[i+2];
+		for (const auto& entry : dirtyEntries) {
+			int idx = entry.index;
+			srcReg[idx] = entry.region;
+			srcDist[idx] = entry.d2;
 		}
 		
 		if (failed*3 == stack.size())


### PR DESCRIPTION
 * We use an STL allocator that wraps rcAlloc/rcFree to make rc-specific aliases for std::vector.
 * Two location where an rcIntArray is used to store structured data are converted to be rcVectors of structs.
 * One location where a dynamic array of uint16's was allocated is converted into an rcVector<unsigned short>.
 * rcIntArray is now implemented in terms of rcVector.

Note that using rcVector saves space in many cases: a "struct { int; short; short }" is 8 bytes vs. 12 for three entries in an rcIntArray. 