### PR TITLE
Add homebrewed rcVector class and tests, and use it to implement rcIntArray.

### DIFF
--- a/Recast/Include/RecastAlloc.h
+++ b/Recast/Include/RecastAlloc.h
@@ -262,7 +262,7 @@ rcVectorBase<T, H>& rcVectorBase<T, H>::operator=(const rcVectorBase<T, H>& othe
 }
 
 template <typename T>
-class rcVector : public	rcVectorBase<T, RC_ALLOC_TEMP> {
+class rcVector : public rcVectorBase<T, RC_ALLOC_TEMP> {
 	typedef rcVectorBase<T, RC_ALLOC_TEMP> Base;
 public:
 	rcVector() : Base() {}
@@ -272,7 +272,7 @@ public:
 	rcVector(const T* begin, const T* end) : Base(begin, end) {}
 };
 template <typename T>
-class rcPermVector : public	rcVectorBase<T, RC_ALLOC_PERM> {
+class rcPermVector : public rcVectorBase<T, RC_ALLOC_PERM> {
 	typedef rcVectorBase<T, RC_ALLOC_PERM> Base;
 public:
 	rcPermVector() : Base() {}

--- a/Recast/Include/RecastAlloc.h
+++ b/Recast/Include/RecastAlloc.h
@@ -22,8 +22,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "RecastAssert.h"
-
 /// Provides hint values to the memory allocator on how long the
 /// memory is expected to be used.
 enum rcAllocHint
@@ -165,7 +163,6 @@ void rcVectorBase<T, H>::reserve(rcSizeType count) {
 }
 template <typename T, rcAllocHint H>
 T* rcVectorBase<T, H>::allocate_and_copy(rcSizeType size) {
-	rcAssert(size > m_size);
 	T* new_data = static_cast<T*>(rcAlloc(sizeof(T) * size, H));
 	copy_range(new_data, m_data, m_data + m_size);
 	return new_data;

--- a/Recast/Include/RecastAlloc.h
+++ b/Recast/Include/RecastAlloc.h
@@ -20,6 +20,9 @@
 #define RECASTALLOC_H
 
 #include <stddef.h>
+#include <stdint.h>
+
+#include "RecastAssert.h"
 
 /// Provides hint values to the memory allocator on how long the
 /// memory is expected to be used.
@@ -58,64 +61,249 @@ void* rcAlloc(size_t size, rcAllocHint hint);
 /// @see rcAlloc
 void rcFree(void* ptr);
 
+/// An implementation of operator new usable for placement new. The default one is part of STL (which we don't use).
+/// rcNewTag is a dummy type used to differentiate our operator from the STL one, in case users import both Recast
+/// and STL.
+struct rcNewTag {};
+inline void* operator new(size_t, const rcNewTag&, void* p) { return p; }
 
-/// A simple dynamic array of integers.
+/// Signed to avoid warnnings when comparing to int loop indexes, and common error with comparing to zero.
+/// MSVC2010 has a bug where ssize_t is unsigned (!!!).
+typedef intptr_t rcSizeType;
+
+/// Macros to hint to the compiler about the likeliest branch. Please add a benchmark that demonstrates a performance
+/// improvement before intrudcing use cases.
+#if defined(__GNUC__) || defined(__clang__)
+#define rcLikely(x) __builtin_expect((x), true)
+#define rcUnlikely(x) __builtin_expect((x), false)
+#else
+#define rcLikely(x) (x)
+#define rcUnlikely(x) (x)
+#endif
+
+/// Variable-sized storage type. Mimics the interface of std::vector<T> with some notable differences:
+///  * Uses rcAlloc()/rcFree() to handle storage.
+///  * No support for a custom allocator.
+///  * Uses signed size instead of size_t to avoid warnings in for loops: "for (int i = 0; i < foo.size(); i++)"
+///  * Omits methods of limited utility: insert/erase (bad performance).
+///  * at() is equivalent to [], as we don't use exceptions.
+///  * assign() and the pre-sizing constructor follow C++11 semantics -- they don't construct a temporary if no value is provided.
+///  * push_back() and resize() support adding values from the current vector. Range-based constructors and assign(begin, end) do not.
+///  * No specialization for bool.
+template <typename T, rcAllocHint H>
+class rcVectorBase {
+	T* m_data;
+	ssize_t m_size;
+	ssize_t m_cap;
+	// Constructs a T at the give address with either the copy constructor or the default.
+	static void construct(T* p, const T& v) { ::new(rcNewTag(), (void*)p) T(v); }
+	static void construct(T* p) { ::new(rcNewTag(), (void*)p) T; }
+	static void construct_range(T* begin, T* end);
+	static void construct_range(T* begin, T* end, const T& value);
+	static void copy_range(T* dst, const T* begin, const T* end);
+	void destroy_range(rcSizeType begin, rcSizeType end);
+	// Creates an array of the given size, copies all of this vector's data into it, and returns it.
+	T* allocate_and_copy(rcSizeType size);
+	void resize_impl(rcSizeType size, const T* value);
+ public:
+	typedef rcSizeType size_type;
+	typedef T value_type;
+
+	rcVectorBase() : m_size(0), m_cap(0), m_data(0) {};
+	rcVectorBase(const rcVectorBase<T, H>& other) : m_size(0), m_cap(0), m_data(0) { assign(other.begin(), other.end()); }
+	explicit rcVectorBase(rcSizeType count) : m_data(0), m_size(0), m_cap(0) { resize(count); }
+	rcVectorBase(rcSizeType count, const T& value) : m_data(0), m_size(0), m_cap(0) { resize(count, value); }
+	rcVectorBase(const T* begin, const T* end) : m_data(0), m_size(0), m_cap(0) { assign(begin, end); }
+	~rcVectorBase() { destroy_range(0, m_size); rcFree(m_data); }
+
+	void reserve(rcSizeType size);
+
+	void assign(rcSizeType count, const T& value) { clear(); resize(count, value); }
+	void assign(const T* begin, const T* end);
+
+	void resize(rcSizeType size) { resize_impl(size, NULL); }
+	void resize(rcSizeType size, const T& value) { resize_impl(size, &value); }
+
+	void push_back(const T& value);
+	void pop_back() { back().~T(); m_size--; }
+	void clear() { resize(0); }
+	rcSizeType size() const { return m_size; }
+	rcSizeType capacity() const { return m_cap; }
+	bool empty() const { return size() == 0; }
+
+	const T& operator[](rcSizeType i) const { return m_data[i]; }
+	T& operator[](rcSizeType i) { return m_data[i]; }
+	const T& at(rcSizeType i) const { return m_data[i]; }
+	T& at(rcSizeType i) { return m_data[i]; }
+
+	const T& front() const { return m_data[0]; }
+	T& front() { return m_data[0]; }
+	const T& back() const { return m_data[m_size - 1]; };
+	T& back() { return m_data[m_size - 1]; };
+	const T* data() const { return m_data; }
+	T* data() { return m_data; }
+
+	T* begin() { return m_data; }
+	T* end() { return m_data + m_size; }
+	const T* begin() const { return m_data; }
+	const T* end() const { return m_data + m_size; }
+
+	void swap(rcVectorBase<T, H>& other);
+	rcVectorBase& operator=(const rcVectorBase<T, H>& other);
+};
+
+template<typename T, rcAllocHint H>
+void rcVectorBase<T, H>::reserve(rcSizeType count) {
+	if (count <= m_cap) {
+		return;
+	}
+	T* new_data = allocate_and_copy(count);
+	destroy_range(0, m_size);
+	rcFree(m_data);
+	m_data = new_data;
+	m_cap = count;
+}
+template <typename T, rcAllocHint H>
+T* rcVectorBase<T, H>::allocate_and_copy(rcSizeType size) {
+	rcAssert(size > m_size);
+	T* new_data = static_cast<T*>(rcAlloc(sizeof(T) * size, H));
+	copy_range(new_data, m_data, m_data + m_size);
+	return new_data;
+}
+template <typename T, rcAllocHint H>
+void rcVectorBase<T, H>::assign(const T* begin, const T* end) {
+	clear();
+	reserve(end - begin);
+	m_size = end - begin;
+	copy_range(m_data, begin, end);
+}
+template <typename T, rcAllocHint H>
+void rcVectorBase<T, H>::push_back(const T& value) {
+	// rcLikely increases performance by ~50% on BM_rcVector_PushPreallocated,
+	// and by ~2-5% on BM_rcVector_Push.
+	if (rcLikely(m_size < m_cap)) {
+		construct(m_data + m_size++, value);
+		return;
+	}
+
+	rcSizeType new_cap = m_size ? 2*m_size : 1;
+	T* data = allocate_and_copy(new_cap);
+	construct(data + m_size, value);
+	destroy_range(0, m_size);
+	m_size++;
+	m_cap = new_cap;
+	rcFree(m_data);
+	m_data = data;
+}
+template <typename T, rcAllocHint H>
+void rcVectorBase<T, H>::resize_impl(rcSizeType size, const T* value) {
+	if (size < m_size) {
+		destroy_range(size, m_size);
+		m_size = size;
+	} else if (size > m_size) {
+		// Assign to temporary in case value is in this vector.
+		T* new_data = allocate_and_copy(size);
+		if (value) {
+			construct_range(new_data + m_size, new_data + size, *value);
+		} else {
+			construct_range(new_data + m_size, new_data + size);
+		}
+		destroy_range(0, m_size);
+		rcFree(m_data);
+		m_data = new_data;
+		m_cap = size;
+		m_size = size;
+	}
+}
+template <typename T, rcAllocHint H>
+void rcVectorBase<T, H>::swap(rcVectorBase<T, H>& other) {
+	rcSizeType tmp_cap = other.m_cap;
+	rcSizeType tmp_size = other.m_size;
+	T* tmp_data = other.m_data;
+
+	other.m_cap = m_cap;
+	other.m_size = m_size;
+	other.m_data = m_data;
+
+	m_cap = tmp_cap;
+	m_size = tmp_size;
+	m_data = tmp_data;
+}
+// static
+template <typename T, rcAllocHint H>
+void rcVectorBase<T, H>::construct_range(T* begin, T* end) {
+	for (T* p = begin; p < end; p++) {
+		construct(p);
+	}
+}
+// static
+template <typename T, rcAllocHint H>
+void rcVectorBase<T, H>::construct_range(T* begin, T* end, const T& value) {
+	for (T* p = begin; p < end; p++) {
+		construct(p, value);
+	}
+}
+// static
+template <typename T, rcAllocHint H>
+void rcVectorBase<T, H>::copy_range(T* dst, const T* begin, const T* end) {
+	for (rcSizeType i = 0 ; i < end - begin; i++) {
+		construct(dst + i, begin[i]);
+	}
+}
+template <typename T, rcAllocHint H>
+void rcVectorBase<T, H>::destroy_range(rcSizeType begin, rcSizeType end) {
+	for (rcSizeType i = begin; i < end; i++) {
+		m_data[i].~T();
+	}
+}
+template <typename T, rcAllocHint H>
+rcVectorBase<T, H>& rcVectorBase<T, H>::operator=(const rcVectorBase<T, H>& other) {
+	if (this != &other) {
+		assign(other.begin(), other.end());
+	}
+	return *this;
+}
+
+template <typename T>
+class rcVector : public	rcVectorBase<T, RC_ALLOC_TEMP> {
+	typedef rcVectorBase<T, RC_ALLOC_TEMP> Base;
+public:
+	rcVector() : Base() {}
+	explicit rcVector(rcSizeType size) : Base(size) {}
+	rcVector(rcSizeType size, const T& value) : Base(size, value) {}
+	rcVector(const rcVector<T>& other) : Base(other) {}
+	rcVector(const T* begin, const T* end) : Base(begin, end) {}
+};
+template <typename T>
+class rcPermVector : public	rcVectorBase<T, RC_ALLOC_PERM> {
+	typedef rcVectorBase<T, RC_ALLOC_PERM> Base;
+public:
+	rcPermVector() : Base() {}
+	explicit rcPermVector(rcSizeType size) : Base(size) {}
+	rcPermVector(rcSizeType size, const T& value) : Base(size, value) {}
+	rcPermVector(const rcPermVector<T>& other) : Base(other) {}
+	rcPermVector(const T* begin, const T* end) : Base(begin, end) {}
+};
+
+
+/// Legacy class. Prefer rcVector<int>.
 class rcIntArray
 {
-	int* m_data;
-	int m_size, m_cap;
-
-	void doResize(int n);
-	
-	// Explicitly disabled copy constructor and copy assignment operator.
-	rcIntArray(const rcIntArray&);
-	rcIntArray& operator=(const rcIntArray&);
-
+	rcVector<int> m_impl;
 public:
-	/// Constructs an instance with an initial array size of zero.
-	rcIntArray() : m_data(0), m_size(0), m_cap(0) {}
-
-	/// Constructs an instance initialized to the specified size.
-	///  @param[in]		n	The initial size of the integer array.
-	rcIntArray(int n) : m_data(0), m_size(0), m_cap(0) { resize(n); }
-	~rcIntArray() { rcFree(m_data); }
-
-	/// Specifies the new size of the integer array.
-	///  @param[in]		n	The new size of the integer array.
-	void resize(int n)
-	{
-		if (n > m_cap)
-			doResize(n);
-		
-		m_size = n;
-	}
-
-	/// Push the specified integer onto the end of the array and increases the size by one.
-	///  @param[in]		item	The new value.
-	void push(int item) { resize(m_size+1); m_data[m_size-1] = item; }
-
-	/// Returns the value at the end of the array and reduces the size by one.
-	///  @return The value at the end of the array.
+	rcIntArray() {}
+	rcIntArray(int n) : m_impl(n, 0) {}
+	void push(int item) { m_impl.push_back(item); }
+	void resize(int size) { m_impl.resize(size); }
 	int pop()
 	{
-		if (m_size > 0)
-			m_size--;
-		
-		return m_data[m_size];
+		int v = m_impl.back();
+		m_impl.pop_back();
+		return v;
 	}
-
-	/// The value at the specified array index.
-	/// @warning Does not provide overflow protection.
-	///  @param[in]		i	The index of the value.
-	const int& operator[](int i) const { return m_data[i]; }
-
-	/// The value at the specified array index.
-	/// @warning Does not provide overflow protection.
-	///  @param[in]		i	The index of the value.
-	int& operator[](int i) { return m_data[i]; }
-
-	/// The current size of the integer array.
-	int size() const { return m_size; }
+	int size() const { return m_impl.size(); }
+	int& operator[](int index) { return m_impl[index]; }
+	int operator[](int index) const { return m_impl[index]; }
 };
 
 /// A simple helper class used to delete an array when it goes out of scope.

--- a/Recast/Source/RecastAlloc.cpp
+++ b/Recast/Source/RecastAlloc.cpp
@@ -58,29 +58,3 @@ void rcFree(void* ptr)
 	if (ptr)
 		sRecastFreeFunc(ptr);
 }
-
-/// @class rcIntArray
-///
-/// While it is possible to pre-allocate a specific array size during 
-/// construction or by using the #resize method, certain methods will 
-/// automatically resize the array as needed.
-///
-/// @warning The array memory is not initialized to zero when the size is 
-/// manually set during construction or when using #resize.
-
-/// @par
-///
-/// Using this method ensures the array is at least large enough to hold
-/// the specified number of elements.  This can improve performance by
-/// avoiding auto-resizing during use.
-void rcIntArray::doResize(int n)
-{
-	if (!m_cap) m_cap = n;
-	while (m_cap < n) m_cap *= 2;
-	int* newData = (int*)rcAlloc(m_cap*sizeof(int), RC_ALLOC_TEMP);
-	rcAssert(newData);
-	if (m_size && newData) memcpy(newData, m_data, m_size*sizeof(int));
-	rcFree(m_data);
-	m_data = newData;
-}
-

--- a/Tests/Recast/Tests_Recast.cpp
+++ b/Tests/Recast/Tests_Recast.cpp
@@ -8,16 +8,6 @@
 
 #include <vector>
 
-
-#ifdef __unix__
-// For rcVector benchmarking.
-#include <unistd.h>
-#ifdef _POSIX_TIMERS
-#include <time.h>
-#include <stdint.h>
-#endif  // _POSIX_TIMERS
-#endif  // __unix__
-
 TEST_CASE("rcSwap")
 {
 	SECTION("Swap two values")
@@ -900,14 +890,6 @@ struct Copier {
 const int Copier::kAlive = 0x1f;
 const int Copier::kDead = 0xde;
 
-#ifdef _POSIX_TIMERS
-int64_t NowNanos() {
-	struct timespec tp;
-	clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &tp);
-	return tp.tv_nsec + 1000000000LL * tp.tv_sec;
-}
-#endif
-
 TEST_CASE("rcVector")
 {
 	SECTION("Vector basics.")
@@ -1119,7 +1101,22 @@ TEST_CASE("rcVector")
 }
 
 // TODO: Implement benchmarking for platforms other than posix.
+#ifdef __unix__
+// For rcVector benchmarking.
+#include <unistd.h>
 #ifdef _POSIX_TIMERS
+#include <time.h>
+#include <stdint.h>
+#endif  // _POSIX_TIMERS
+#endif  // __unix__
+
+#ifdef _POSIX_TIMERS
+int64_t NowNanos() {
+	struct timespec tp;
+	clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &tp);
+	return tp.tv_nsec + 1000000000LL * tp.tv_sec;
+}
+
 #define BM(name, iterations) \
 	struct BM_ ## name { \
 		static void Run() { \

--- a/Tests/Recast/Tests_Recast.cpp
+++ b/Tests/Recast/Tests_Recast.cpp
@@ -1,6 +1,22 @@
+#include <string.h>
+
 #include "catch.hpp"
 
 #include "Recast.h"
+#include "RecastAlloc.h"
+#include "RecastAssert.h"
+
+#include <vector>
+
+
+#ifdef __unix__
+// For rcVector benchmarking.
+#include <unistd.h>
+#ifdef _POSIX_TIMERS
+#include <time.h>
+#include <stdint.h>
+#endif  // _POSIX_TIMERS
+#endif  // __unix__
 
 TEST_CASE("rcSwap")
 {
@@ -828,3 +844,423 @@ TEST_CASE("rcRasterizeTriangles")
 		REQUIRE(!solid.spans[1 + 2 * width]->next);
 	}
 }
+
+// Used to verify that rcVector constructs/destroys objects correctly.
+struct Incrementor {
+	static int constructions;
+	static int destructions;
+	static int copies;
+	Incrementor() { constructions++; }
+	~Incrementor() { destructions++; }
+	Incrementor(const Incrementor& other) { copies++; }
+	Incrementor& operator=(const Incrementor& other); // Deleted assignment.
+
+	static void Reset() {
+		constructions = 0;
+		destructions = 0;
+		copies = 0;
+	}
+};
+int Incrementor::constructions = 0;
+int Incrementor::destructions = 0;
+int Incrementor::copies = 0;
+
+const int kMaxAllocSize = 1024;
+const unsigned char kClearValue = 0xff;
+// Simple alloc/free that clears the memory on free..
+void* AllocAndInit(size_t size, rcAllocHint) {
+	rcAssert(kMaxAllocSize >= size);
+	return memset(malloc(kMaxAllocSize), 0, kMaxAllocSize);
+}
+void FreeAndClear(void* mem) {
+	if (mem) {
+	  memset(mem, kClearValue, kMaxAllocSize);
+	}
+	free(mem);
+}
+// Verifies that memory has been initialized by AllocAndInit, and not cleared by FreeAndClear.
+struct Copier {
+	const static int kAlive;
+	const static int kDead;
+	Copier() : value(kAlive) {}
+
+	// checks that the source of the copy is valid.
+	Copier(const Copier& other) : value(kAlive) {
+		other.Verify();
+	}
+	Copier& operator=(const Copier& other);
+
+	// Marks the value as dead.
+	~Copier() { value = kDead; }
+	void Verify() const {
+		REQUIRE(value == kAlive);
+	}
+	volatile int value;
+};
+const int Copier::kAlive = 0x1f;
+const int Copier::kDead = 0xde;
+
+#ifdef _POSIX_TIMERS
+int64_t NowNanos() {
+	struct timespec tp;
+	clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &tp);
+	return tp.tv_nsec + 1000000000LL * tp.tv_sec;
+}
+#endif
+
+TEST_CASE("rcVector")
+{
+	SECTION("Vector basics.")
+	{
+		rcVector<int> vec;
+		REQUIRE(vec.size() == 0);
+		vec.push_back(10);
+		vec.push_back(12);
+		REQUIRE(vec.size() == 2);
+		REQUIRE(vec.capacity() >= 2);
+		REQUIRE(vec[0] == 10);
+		REQUIRE(vec[1] == 12);
+		vec.pop_back();
+		REQUIRE(vec.size() == 1);
+		REQUIRE(vec[0] == 10);
+		vec.pop_back();
+		REQUIRE(vec.size() == 0);
+		vec.resize(100, 5);
+		REQUIRE(vec.size() == 100);
+		for (int i = 0; i < 100; i++) {
+			REQUIRE(vec[i] == 5);
+			vec[i] = i;
+		}
+		for (int i = 0; i < 100; i++) {
+			REQUIRE(vec[i] == i);
+		}
+	}
+
+	SECTION("Constructors/Destructors")
+	{
+		Incrementor::Reset();
+		rcVector<Incrementor> vec;
+		REQUIRE(Incrementor::constructions == 0);
+		REQUIRE(Incrementor::destructions == 0);
+		REQUIRE(Incrementor::copies == 0);
+		vec.push_back(Incrementor());
+		// push_back() may create and copy objects internally.
+		REQUIRE(Incrementor::constructions == 1);
+		REQUIRE(Incrementor::destructions >= 1);
+		// REQUIRE(Incrementor::copies >= 2);
+
+		vec.clear();
+		Incrementor::Reset();
+		vec.resize(100);
+		// Initialized with default instance. Temporaries may be constructed, then destroyed.
+		REQUIRE(Incrementor::constructions == 100);
+		REQUIRE(Incrementor::destructions == 0);
+		REQUIRE(Incrementor::copies == 0);
+
+		Incrementor::Reset();
+		for (int i = 0; i < 100; i++) {
+			REQUIRE(Incrementor::destructions == i);
+			vec.pop_back();
+		}
+		REQUIRE(Incrementor::constructions == 0);
+		REQUIRE(Incrementor::destructions == 100);
+		REQUIRE(Incrementor::copies == 0);
+
+		vec.resize(100);
+		Incrementor::Reset();
+		vec.clear();
+		// One temp object is constructed for the default argumnet of resize().
+		REQUIRE(Incrementor::constructions == 0);
+		REQUIRE(Incrementor::destructions == 100);
+		REQUIRE(Incrementor::copies == 0);
+
+		Incrementor::Reset();
+		vec.resize(100, Incrementor());
+		REQUIRE(Incrementor::constructions == 1);
+		REQUIRE(Incrementor::destructions == 1);
+		REQUIRE(Incrementor::copies == 100);
+	}
+
+	SECTION("Copying Contents")
+	{
+
+		// veriyf event counts after doubling size -- should require a lot of copying and destorying.
+		rcVector<Incrementor> vec;
+		Incrementor::Reset();
+		vec.resize(100);
+		REQUIRE(Incrementor::constructions == 100);
+		REQUIRE(Incrementor::destructions == 0);
+		REQUIRE(Incrementor::copies == 0);
+		Incrementor::Reset();
+		vec.resize(200);
+		REQUIRE(vec.size() == vec.capacity());
+		REQUIRE(Incrementor::constructions == 100);  // Construc new elements.
+		REQUIRE(Incrementor::destructions == 100);  // Destroy old contents.
+		REQUIRE(Incrementor::copies == 100);  // Copy old elements into new array.
+	}
+
+	SECTION("Swap")
+	{
+		rcVector<int> a(10, 0xa);
+		rcVector<int> b;
+
+		int* a_data = a.data();
+		int* b_data = b.data();
+
+		a.swap(b);
+		REQUIRE(a.size() == 0);
+		REQUIRE(b.size() == 10);
+		REQUIRE(b[0] == 0xa);
+		REQUIRE(b[9] == 0xa);
+		REQUIRE(a.data() == b_data);
+		REQUIRE(b.data() == a_data);
+	}
+
+	SECTION("Overlapping init")
+	{
+		rcAllocSetCustom(&AllocAndInit, &FreeAndClear);
+		rcVector<Copier> vec;
+		// Force a realloc during push_back().
+		vec.resize(64);
+		REQUIRE(vec.capacity() == vec.size());
+		REQUIRE(vec.capacity() > 0);
+		REQUIRE(vec.size() == vec.capacity());
+
+		// Don't crash.
+		vec.push_back(vec[0]);
+		rcAllocSetCustom(NULL, NULL);
+	}
+
+	SECTION("Vector Destructor")
+	{
+		{
+			rcVector<Incrementor> vec;
+			vec.resize(10);
+			Incrementor::Reset();
+		}
+		REQUIRE(Incrementor::destructions == 10);
+	}
+
+	SECTION("Assign")
+	{
+		rcVector<int> a(10, 0xa);
+		a.assign(5, 0xb);
+		REQUIRE(a.size() == 5);
+		REQUIRE(a[0] == 0xb);
+		REQUIRE(a[4] == 0xb);
+		a.assign(15, 0xc);
+		REQUIRE(a.size() == 15);
+		REQUIRE(a[0] == 0xc);
+		REQUIRE(a[14] == 0xc);
+
+		rcVector<int> b;
+		b.assign(a.data(), a.data() + a.size());
+		REQUIRE(b.size() == a.size());
+		REQUIRE(b[0] == a[0]);
+	}
+
+	SECTION("Assign=")
+	{
+		rcVector<int> a(10, 0xa);
+		rcVector<int> b;
+		a = a;
+		REQUIRE(a[0] == 0xa);
+		REQUIRE(a.size() == 10);
+		b = a;
+		REQUIRE(b[0] == a[0]);
+		REQUIRE(b.size() == a.size());
+
+		rcVector<Incrementor> c(100);
+		rcVector<Incrementor> d;
+		Incrementor::Reset();
+		c = c;
+		REQUIRE(c.size() == 100);
+		REQUIRE(Incrementor::constructions == 0);
+		REQUIRE(Incrementor::destructions == 0);
+		REQUIRE(Incrementor::copies == 0);
+		// Doesn't overwrite anything, so only copies.
+		d = c;
+		REQUIRE(d.size() == 100);
+		REQUIRE(Incrementor::constructions == 0);
+		REQUIRE(Incrementor::destructions == 0);
+		REQUIRE(Incrementor::copies == 100);
+		Incrementor::Reset();
+		d = c;
+		REQUIRE(Incrementor::constructions == 0);
+		REQUIRE(Incrementor::destructions == 100);
+		REQUIRE(Incrementor::copies == 100);
+	}
+
+	SECTION("Copy")
+	{
+		rcVector<int> a(10, 0xa);
+		rcVector<int> b(a);
+		REQUIRE(a.size() == 10);
+		REQUIRE(a.size() == b.size());
+		REQUIRE(a[0] == b[0]);
+		REQUIRE(a.data() != b.data());
+		rcVector<int> c(a.data(), a.data() + a.size());
+		REQUIRE(c.size() == a.size());
+		REQUIRE(c[0] == a[0]);
+
+		rcVector<Incrementor> d(10);
+		Incrementor::Reset();
+		rcVector<Incrementor> e(d);
+		REQUIRE(Incrementor::constructions == 0);
+		REQUIRE(Incrementor::destructions == 0);
+		REQUIRE(Incrementor::copies == 10);
+
+		Incrementor::Reset();
+		rcVector<Incrementor> f(d.data(), d.data() + d.size());
+		REQUIRE(Incrementor::constructions == 0);
+		REQUIRE(Incrementor::destructions == 0);
+		REQUIRE(Incrementor::copies == 10);
+	}
+}
+
+// TODO: Implement benchmarking for platforms other than posix.
+#ifdef _POSIX_TIMERS
+#define BM(name, iterations) \
+	struct BM_ ## name { \
+		static void Run() { \
+			int64_t begin_time = NowNanos(); \
+			for (int i = 0 ; i < iterations; i++) { \
+				Body(); \
+			} \
+			int64_t nanos = NowNanos() - begin_time; \
+			printf("BM_%-35s %ld iterations in %10ld nanos: %10.2f nanos/it\n", #name ":", (int64_t)iterations, nanos, double(nanos) / iterations); \
+		} \
+		static void Body(); \
+	}; \
+	TEST_CASE(#name) { \
+		BM_ ## name::Run(); \
+	} \
+	void BM_ ## name::Body()
+
+const int64_t kNumLoops = 100;
+const int64_t kNumInserts = 100000;
+const int64_t kNumOps = kNumLoops * kNumInserts;
+
+// Prevent compiler from eliding the above loop. gcc/clang only?
+template <typename T>
+void DoNotOptimize(T* v) {
+	asm volatile ("" : "+r" (v));
+}
+
+BM(FlatArray_Push, kNumLoops)
+{
+	int cap = 64;
+	int* v = (int*)rcAlloc(cap * sizeof(int), RC_ALLOC_TEMP);
+	for (int j = 0; j < kNumInserts; j++) {
+		if (j == cap) {
+			cap *= 2;
+			int* tmp  = (int*)rcAlloc(sizeof(int) * cap, RC_ALLOC_TEMP);
+			memcpy(tmp, v, j * sizeof(int));
+			rcFree(v);
+			v = tmp;
+		}
+		v[j] = 2;
+	}
+
+	DoNotOptimize(v);
+	rcFree(v);
+}
+BM(FlatArray_Fill, kNumLoops)
+{
+	int* v = (int*)rcAlloc(sizeof(int) * kNumInserts, RC_ALLOC_TEMP);
+	for (int j = 0; j < kNumInserts; j++) {
+		v[j] = 2;
+	}
+
+	DoNotOptimize(v);
+	rcFree(v);
+}
+BM(FlatArray_Memset, kNumLoops)
+{
+	int* v = (int*)rcAlloc(sizeof(int) * kNumInserts, RC_ALLOC_TEMP);
+	memset(v, 0, kNumInserts * sizeof(int));
+
+	DoNotOptimize(v);
+	rcFree(v);
+}
+
+BM(rcVector_Push, kNumLoops)
+{
+	rcVector<int> v;
+	for (int j = 0; j < kNumInserts; j++) {
+		v.push_back(2);
+	}
+	DoNotOptimize(v.data());
+}
+BM(rcVector_PushPreallocated, kNumLoops)
+{
+	rcVector<int> v;
+	v.reserve(kNumInserts);
+	for (int j = 0; j < kNumInserts; j++) {
+		v.push_back(2);
+	}
+	DoNotOptimize(v.data());
+}
+BM(rcVector_Assign, kNumLoops)
+{
+	rcVector<int> v;
+	v.assign(kNumInserts, 2);
+	DoNotOptimize(v.data());
+}
+BM(rcVector_AssignIndices, kNumLoops)
+{
+	rcVector<int> v;
+	v.resize(kNumInserts);
+	for (int j = 0; j < kNumInserts; j++) {
+		v[j] = 2;
+	}
+	DoNotOptimize(v.data());
+}
+BM(rcVector_Resize, kNumLoops)
+{
+	rcVector<int> v;
+	v.resize(kNumInserts, 2);
+	DoNotOptimize(v.data());
+}
+
+BM(stdvector_Push, kNumLoops)
+{
+	std::vector<int> v;
+	for (int j = 0; j < kNumInserts; j++) {
+		v.push_back(2);
+	}
+	DoNotOptimize(v.data());
+}
+BM(stdvector_PushPreallocated, kNumLoops)
+{
+	std::vector<int> v;
+	v.reserve(kNumInserts);
+	for (int j = 0; j < kNumInserts; j++) {
+		v.push_back(2);
+	}
+	DoNotOptimize(v.data());
+}
+BM(stdvector_Assign, kNumLoops)
+{
+	std::vector<int> v;
+	v.assign(kNumInserts, 2);
+	DoNotOptimize(v.data());
+}
+BM(stdvector_AssignIndices, kNumLoops)
+{
+	std::vector<int> v;
+	v.resize(kNumInserts);
+	for (int j = 0; j < kNumInserts; j++) {
+		v[j] = 2;
+	}
+	DoNotOptimize(v.data());
+}
+BM(stdvector_Resize, kNumLoops)
+{
+	std::vector<int> v;
+	v.resize(kNumInserts, 2);
+	DoNotOptimize(v.data());
+}
+
+#undef BM
+#endif  // ifdef _POSIX_TIMERS

--- a/Tests/Recast/Tests_Recast.cpp
+++ b/Tests/Recast/Tests_Recast.cpp
@@ -1136,7 +1136,6 @@ int64_t NowNanos() {
 
 const int64_t kNumLoops = 100;
 const int64_t kNumInserts = 100000;
-const int64_t kNumOps = kNumLoops * kNumInserts;
 
 // Prevent compiler from eliding the above loop. gcc/clang only?
 template <typename T>


### PR DESCRIPTION
This implements most of the std::vector interface, with some minor elisions of
infrequently used methods such as "insert", and some STL bookkeeping.
 Performance is favorable compared to std::vector, and, in some cases, somewhat
better than naive code to manually manage a malloc'd dynamic array.

BM_FlatArray_Push:                     100 iterations in   72889721 nanos:  728897.21 nanos/it
BM_FlatArray_Fill:                     100 iterations in    2700746 nanos:   27007.46 nanos/it
BM_FlatArray_Memset:                   100 iterations in    2687810 nanos:   26878.10 nanos/it
BM_rcVector_Push:                      100 iterations in   51114316 nanos:  511143.16 nanos/it
BM_rcVector_PushPreallocated:          100 iterations in    9532106 nanos:   95321.06 nanos/it
BM_rcVector_Assign:                    100 iterations in    2371534 nanos:   23715.34 nanos/it
BM_rcVector_AssignIndices:             100 iterations in    2573052 nanos:   25730.52 nanos/it
BM_rcVector_Resize:                    100 iterations in    2455761 nanos:   24557.61 nanos/it
BM_stdvector_Push:                     100 iterations in   71739167 nanos:  717391.67 nanos/it
BM_stdvector_PushPreallocated:         100 iterations in   15723737 nanos:  157237.37 nanos/it
BM_stdvector_Assign:                   100 iterations in    2564985 nanos:   25649.85 nanos/it
BM_stdvector_AssignIndices:            100 iterations in    5174923 nanos:   51749.23 nanos/it
BM_stdvector_Resize:                   100 iterations in    2520054 nanos:   25200.54 nanos/it