### PR TITLE
Call proper memory deallocation function in `dtDecompressTileCacheLayer`.

### DIFF
--- a/DetourTileCache/Source/DetourTileCacheBuilder.cpp
+++ b/DetourTileCache/Source/DetourTileCacheBuilder.cpp
@@ -2196,7 +2196,7 @@ dtStatus dtDecompressTileCacheLayer(dtTileCacheAlloc* alloc, dtTileCacheCompress
 									   grids, gridsSize, &size);
 	if (dtStatusFailed(status))
 	{
-		dtFree(buffer);
+		alloc->free(buffer);
 		return status;
 	}
 	


### PR DESCRIPTION
In function `dtDecompressTileCacheLayer` buffer is allocated using a call to `dtTileCacheAlloc::alloc` (`DetourTileCacheBuilder.cpp`. line 2181). But if call to `comp->decompress` below fails, `dtFree` is used instead to deallocate the memory (line 2199, which this pull request fixes).

This happens to work for most of the users, because default implementation of `dtTileCacheAlloc::free` calls `dtFree` itself. But it breaks in rare circumstances when you use custom memory allocation *and* decompression fails.

This request fixes that.