### PR TITLE
Switch expandRegions to using a rcTempVector of structs rather than a blob of ints.

### DIFF
--- a/Recast/Include/RecastAlloc.h
+++ b/Recast/Include/RecastAlloc.h
@@ -123,10 +123,12 @@ class rcVectorBase {
 
 	void resize(rcSizeType size) { resize_impl(size, NULL); }
 	void resize(rcSizeType size, const T& value) { resize_impl(size, &value); }
+	// Not implemented as resize(0) because resize requires T to be default-constructible.
+	void clear() { destroy_range(0, m_size); m_size = 0; }
 
 	void push_back(const T& value);
 	void pop_back() { rcAssert(m_size > 0); back().~T(); m_size--; }
-	void clear() { resize(0); }
+
 	rcSizeType size() const { return m_size; }
 	rcSizeType capacity() const { return m_cap; }
 	bool empty() const { return size() == 0; }

--- a/Tests/Recast/Tests_Recast.cpp
+++ b/Tests/Recast/Tests_Recast.cpp
@@ -892,6 +892,10 @@ struct Copier {
 const int Copier::kAlive = 0x1f;
 const int Copier::kDead = 0xde;
 
+struct NotDefaultConstructible {
+	NotDefaultConstructible(int) {}
+};
+
 TEST_CASE("rcVector")
 {
 	SECTION("Vector basics.")
@@ -1067,6 +1071,17 @@ TEST_CASE("rcVector")
 		REQUIRE(Incrementor::constructions == 0);
 		REQUIRE(Incrementor::destructions == 0);
 		REQUIRE(Incrementor::copies == 10);
+	}
+
+	SECTION("Type Requirements")
+	{
+		// This section verifies that we don't enforce unnecessary
+		// requirements on the types we hold.
+
+		// Implementing clear as resize(0) will cause this to fail
+		// as resize(0) requires T to be default constructible.
+		rcTempVector<NotDefaultConstructible> v;
+		v.clear();
 	}
 }
 


### PR DESCRIPTION
Also updates rcVector::clear() to not require the contained type to be default-constructible.