### PR TITLE
Add rcNew/rcDelete, template functions that allocate/deallocate objects using rcAlloc/rcFree.

### DIFF
--- a/Recast/Include/Recast.h
+++ b/Recast/Include/Recast.h
@@ -332,6 +332,8 @@ struct rcCompactSpan
 /// @ingroup recast
 struct rcCompactHeightfield
 {
+	rcCompactHeightfield();
+	~rcCompactHeightfield();
 	int width;					///< The width of the heightfield. (Along the x-axis in cell units.)
 	int height;					///< The height of the heightfield. (Along the z-axis in cell units.)
 	int spanCount;				///< The number of spans in the heightfield.

--- a/Recast/Include/RecastAlloc.h
+++ b/Recast/Include/RecastAlloc.h
@@ -67,6 +67,26 @@ void rcFree(void* ptr);
 struct rcNewTag {};
 inline void* operator new(size_t, const rcNewTag&, void* p) { return p; }
 
+/// Allocates and constructs an object of the given type, returning a pointer.
+/// TODO: Support constructor args.
+/// @param[in]		hint	Hint to the allocator.
+template <typename T>
+T* rcNew(rcAllocHint hint) {
+	T* ptr = (T*)rcAlloc(sizeof(T), hint);
+	::new(rcNewTag(), (void*)ptr) T();
+	return ptr;
+}
+
+/// Destroys and frees an object allocated with rcNew.
+/// @param[in]     ptr    The object pointer to delete.
+template <typename T>
+void rcDelete(T* ptr) {
+	if (ptr) {
+		ptr->~T();
+		rcFree((void*)ptr);
+	}
+}
+
 /// Signed to avoid warnnings when comparing to int loop indexes, and common error with comparing to zero.
 /// MSVC2010 has a bug where ssize_t is unsigned (!!!).
 typedef intptr_t rcSizeType;

--- a/Recast/Include/RecastAlloc.h
+++ b/Recast/Include/RecastAlloc.h
@@ -67,26 +67,6 @@ void rcFree(void* ptr);
 struct rcNewTag {};
 inline void* operator new(size_t, const rcNewTag&, void* p) { return p; }
 
-/// Allocates and constructs an object of the given type, returning a pointer.
-/// TODO: Support constructor args.
-/// @param[in]		hint	Hint to the allocator.
-template <typename T>
-T* rcNew(rcAllocHint hint) {
-	T* ptr = (T*)rcAlloc(sizeof(T), hint);
-	::new(rcNewTag(), (void*)ptr) T();
-	return ptr;
-}
-
-/// Destroys and frees an object allocated with rcNew.
-/// @param[in]     ptr    The object pointer to delete.
-template <typename T>
-void rcDelete(T* ptr) {
-	if (ptr) {
-		ptr->~T();
-		rcFree((void*)ptr);
-	}
-}
-
 /// Signed to avoid warnnings when comparing to int loop indexes, and common error with comparing to zero.
 /// MSVC2010 has a bug where ssize_t is unsigned (!!!).
 typedef intptr_t rcSizeType;

--- a/Recast/Source/Recast.cpp
+++ b/Recast/Source/Recast.cpp
@@ -149,6 +149,8 @@ rcCompactHeightfield::rcCompactHeightfield()
 	borderSize(0),
 	maxDistance(0),
 	maxRegions(0),
+	bmin(),
+	bmax(),
 	cs(0),
 	ch(0),
 	cells(0),
@@ -156,8 +158,6 @@ rcCompactHeightfield::rcCompactHeightfield()
 	dist(0),
 	areas(0)
 {
-	memset(bmin, 0, sizeof(bmin));
-	memset(bmax, 0, sizeof(bmax));
 }
 rcCompactHeightfield::~rcCompactHeightfield()
 {

--- a/Recast/Source/Recast.cpp
+++ b/Recast/Source/Recast.cpp
@@ -23,10 +23,33 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdarg.h>
-#include <new>
 #include "Recast.h"
 #include "RecastAlloc.h"
 #include "RecastAssert.h"
+
+namespace
+{
+/// Allocates and constructs an object of the given type, returning a pointer.
+/// TODO: Support constructor args.
+/// @param[in]		hint	Hint to the allocator.
+template <typename T>
+T* rcNew(rcAllocHint hint) {
+	T* ptr = (T*)rcAlloc(sizeof(T), hint);
+	::new(rcNewTag(), (void*)ptr) T();
+	return ptr;
+}
+
+/// Destroys and frees an object allocated with rcNew.
+/// @param[in]     ptr    The object pointer to delete.
+template <typename T>
+void rcDelete(T* ptr) {
+	if (ptr) {
+		ptr->~T();
+		rcFree((void*)ptr);
+	}
+}
+}  // namespace
+
 
 float rcSqrt(float x)
 {

--- a/Recast/Source/Recast.cpp
+++ b/Recast/Source/Recast.cpp
@@ -133,7 +133,6 @@ rcCompactHeightfield::rcCompactHeightfield()
 	dist(0),
 	areas(0)
 {
-	// TODO: Use something like std::array to store bmin/bmax?
 	memset(bmin, 0, sizeof(bmin));
 	memset(bmax, 0, sizeof(bmax));
 }

--- a/Recast/Source/Recast.cpp
+++ b/Recast/Source/Recast.cpp
@@ -73,7 +73,7 @@ void rcContext::log(const rcLogCategory category, const char* format, ...)
 
 rcHeightfield* rcAllocHeightfield()
 {
-	return new (rcAlloc(sizeof(rcHeightfield), RC_ALLOC_PERM)) rcHeightfield;
+	return rcNew<rcHeightfield>(RC_ALLOC_PERM);
 }
 
 rcHeightfield::rcHeightfield()
@@ -104,26 +104,45 @@ rcHeightfield::~rcHeightfield()
 
 void rcFreeHeightField(rcHeightfield* hf)
 {
-	if (!hf) return;
-	hf->~rcHeightfield();
-	rcFree(hf);
+	rcDelete(hf);
 }
 
 rcCompactHeightfield* rcAllocCompactHeightfield()
 {
-	rcCompactHeightfield* chf = (rcCompactHeightfield*)rcAlloc(sizeof(rcCompactHeightfield), RC_ALLOC_PERM);
-	memset(chf, 0, sizeof(rcCompactHeightfield));
-	return chf;
+	return rcNew<rcCompactHeightfield>(RC_ALLOC_PERM);
 }
 
 void rcFreeCompactHeightfield(rcCompactHeightfield* chf)
 {
-	if (!chf) return;
-	rcFree(chf->cells);
-	rcFree(chf->spans);
-	rcFree(chf->dist);
-	rcFree(chf->areas);
-	rcFree(chf);
+	rcDelete(chf);
+}
+
+rcCompactHeightfield::rcCompactHeightfield()
+	: width(0),
+	height(0),
+	spanCount(0),
+	walkableHeight(0),
+	walkableClimb(0),
+	borderSize(0),
+	maxDistance(0),
+	maxRegions(0),
+	cs(0),
+	ch(0),
+	cells(0),
+	spans(0),
+	dist(0),
+	areas(0)
+{
+	// TODO: Use something like std::array to store bmin/bmax?
+	memset(bmin, 0, sizeof(bmin));
+	memset(bmax, 0, sizeof(bmax));
+}
+rcCompactHeightfield::~rcCompactHeightfield()
+{
+	rcFree(cells);
+	rcFree(spans);
+	rcFree(dist);
+	rcFree(areas);
 }
 
 rcHeightfieldLayerSet* rcAllocHeightfieldLayerSet()


### PR DESCRIPTION
The intention is to use these to move construction logic out of rcAllocateFooObject/rcFreeFooObject and into constructors/destructors, giving users flexibility in how objects are allocated. In particular, this allows stack allocation.

Turns rcAllocateCompactHeightfield into a wrapper around rcNew as a demo. If accepted, PR's for other user objects to follow.