### PR TITLE
Update Premake and treat warnings as errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,12 @@ install:
   - make install
   - cd ..
   # Download and build premake5 from source; the Travis environment doesn't have the right version of glibc6 for the prebuilt binaries to work.
-  - wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha6/premake-5.0.0-alpha6-src.zip -O premake.zip
+  - wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha12/premake-5.0.0-alpha12-src.zip -O premake.zip
   - unzip premake.zip
-  - cd premake-5.0.0-alpha6/build/gmake.unix
+  - cd premake-5.0.0-alpha12/build/gmake.unix
   - make config=release
   - cd ../../..
-  - mv premake-5.0.0-alpha6/bin/release/premake5 premake5
+  - mv premake-5.0.0-alpha12/bin/release/premake5 premake5
 
 # Run premake to generate makefiles.
 # Have to cd into directory and back out since premake5 doesn't appear to accept a directory argument.

--- a/RecastDemo/premake5.lua
+++ b/RecastDemo/premake5.lua
@@ -13,14 +13,12 @@ solution "recastnavigation"
 	}
 	location (todir)
 
-	-- extra warnings, no exceptions or rtti
-	flags { 
-		"ExtraWarnings",
-		"FloatFast",
-		"Symbols"
-	}
+	floatingpoint "Fast"
+	warnings "Extra"
+	symbols "On"
 	exceptionhandling "Off"
 	rtti "Off"
+	flags { "FatalCompileWarnings" }
 
 	-- debug configs
 	configuration "Debug*"
@@ -30,7 +28,7 @@ solution "recastnavigation"
  	-- release configs
 	configuration "Release*"
 		defines { "NDEBUG" }
-		flags { "Optimize" }
+		optimize "On"
 		targetdir ( todir .. "/lib/Release" )
 
 	-- windows specific
@@ -39,10 +37,6 @@ solution "recastnavigation"
 
 	-- linux specific
 	configuration { "linux", "gmake" }
-		buildoptions {
-			"-Wall",
-			"-Werror"
-		}
 
 project "DebugUtils"
 	language "C++"
@@ -171,7 +165,6 @@ project "RecastDemo"
 	configuration { "macosx" }
 		kind "ConsoleApp" -- xcode4 failes to run the project if using WindowedApp
 		includedirs { "/Library/Frameworks/SDL2.framework/Headers" }
-		buildoptions { "-Wunused-value -Wshadow -Wreorder -Wsign-compare -Wall" }
 		links { 
 			"OpenGL.framework", 
 			"SDL2.framework",
@@ -248,7 +241,6 @@ project "Tests"
 	configuration { "macosx" }
 		kind "ConsoleApp"
 		includedirs { "/Library/Frameworks/SDL2.framework/Headers" }
-		buildoptions { "-Wunused-value -Wshadow -Wreorder -Wsign-compare -Wall" }
 		links { 
 			"OpenGL.framework", 
 			"SDL2.framework",

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,13 +5,13 @@ os:
 
 environment:
   matrix:
-  - TOOLSET: vs2010
   - TOOLSET: vs2013
   - TOOLSET: vs2015
+  - TOOLSET: vs2017
 
 install:
   # Download Premake
-  - ps: Start-FileDownload 'https://github.com/premake/premake-core/releases/download/v5.0.0-alpha7/premake-5.0.0-alpha7-windows.zip' 'premake.zip'
+  - ps: Start-FileDownload 'https://github.com/premake/premake-core/releases/download/v5.0.0-alpha12/premake-5.0.0-alpha12-windows.zip' 'premake.zip'
   
   # Extract it in-place; premake5.exe is at the top level.
   - 7z x premake.zip


### PR DESCRIPTION
Update Premake in Travis and AppVeyor to alpha12 and fix premake5.lua. Also ensure we treat warnings as errors.
This ought to fail because of #318.