### PR TITLE
Attempts to make build work on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,10 @@ option(RECASTNAVIGATION_TESTS "Build tests" ON)
 option(RECASTNAVIGATION_EXAMPLES "Build examples" ON)
 option(RECASTNAVIGATION_STATIC "Build static libraries" OFF)
 
+if (WIN32)
+    set(RECASTNAVIGATION_STATIC ON)
+endif()
+
 add_subdirectory(DebugUtils)
 add_subdirectory(Detour)
 add_subdirectory(DetourCrowd)

--- a/DebugUtils/CMakeLists.txt
+++ b/DebugUtils/CMakeLists.txt
@@ -23,4 +23,5 @@ install(TARGETS DebugUtils
         )
 
 file(GLOB INCLUDES Include/*.h)
+
 install(FILES ${INCLUDES} DESTINATION include)

--- a/RecastDemo/CMakeLists.txt
+++ b/RecastDemo/CMakeLists.txt
@@ -1,12 +1,16 @@
 file(GLOB SOURCES Source/*.cpp Contrib/fastlz/fastlz.c)
 
-include(cmake/FindSDL2.cmake)
+LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+if (WIN32)
+	set(SDL2_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/contrib/SDL")
+endif()
 
 find_package(OpenGL REQUIRED)
 find_package(SDL2 REQUIRED)
 
 include_directories(SYSTEM ${OPENGL_INCLUDE_DIR})
-include_directories(SYSTEM ${SDL2_INCLUDE_DIRS})
+include_directories(SYSTEM ${SDL2_INCLUDE_DIR})
 include_directories(SYSTEM Contrib/fastlz)
 include_directories(SYSTEM Contrib)
 include_directories(../DebugUtils/Include)

--- a/RecastDemo/Source/main.cpp
+++ b/RecastDemo/Source/main.cpp
@@ -69,6 +69,7 @@ static SampleItem g_samples[] =
 };
 static const int g_nsamples = sizeof(g_samples) / sizeof(SampleItem);
 
+#undef main
 int main(int /*argc*/, char** /*argv*/)
 {
 	// Init SDL


### PR DESCRIPTION
Copy of #335, Travis seemed to be stuck on an old ref...

Update Premake in Travis and AppVeyor to alpha12 and fix premake5.lua. Also ensure we treat warnings as errors.
This ought to fail because of #318.