### PR TITLE
Add Clang and VS2017 to CI and fix warnings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,7 @@ root = true
 [*]
 indent_size = 4
 indent_style = tab
+
+[*.yml]
+indent_size = 2
+indent_style = space

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,36 +5,22 @@ language: cpp
 # Build with gcc and clang.
 compiler:
   - gcc
-# Disable clang for now since it seems there's a problem using it with fast fp math; it's likely Travis' ancient environment that's at fault.
-#  - clang
+  - clang
 
 # Build both debug and release configurations, through use of an environment variable in the build matrix.
 env:
-  - CONFIGURATION: debug
-    CMAKE_BUILD_TYPE: Debug
-  - CONFIGURATION: release
-    CMAKE_BUILD_TYPE: Release
+  - BUILD_TYPE=debug CMAKE_BUILD_TYPE=Debug
+  - BUILD_TYPE=release CMAKE_BUILD_TYPE=Release
+
+addons:
+  apt:
+    packages:
+      - libsdl2-dev
 
 install:
-  # Download and build SDL2 from source.
-  - mkdir dummyprefix
-  - export PREFIX=$PWD/dummyprefix
-  - export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig
-  - export PATH=$PATH:$PWD/dummyprefix/bin
-  - wget https://www.libsdl.org/release/SDL2-2.0.4.tar.gz -O SDL2.tar.gz
-  - tar -xzf SDL2.tar.gz
-  - cd SDL2-2.0.4
-  - ./configure --prefix=$PREFIX
-  - make -j$(nproc)
-  - make install
-  - cd ..
-  # Download and build premake5 from source; the Travis environment doesn't have the right version of glibc6 for the prebuilt binaries to work.
-  - wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha6/premake-5.0.0-alpha6-src.zip -O premake.zip
-  - unzip premake.zip
-  - cd premake-5.0.0-alpha6/build/gmake.unix
-  - make config=release
-  - cd ../../..
-  - mv premake-5.0.0-alpha6/bin/release/premake5 premake5
+  - wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha12/premake-5.0.0-alpha12-linux.tar.gz -O premake.tar.gz
+  - tar -xf premake.tar.gz
+  - rm premake.tar.gz
 
 # Run premake to generate makefiles.
 # Have to cd into directory and back out since premake5 doesn't appear to accept a directory argument.
@@ -44,7 +30,7 @@ before_script:
 
 # Run make in the directory containing generated makefiles, on the configuration specified by the environment variable.
 script:
-  - make -C RecastDemo/Build/gmake -j$(nproc) config=$CONFIGURATION
+  - make -C RecastDemo/Build/gmake -j$(nproc) config=${BUILD_TYPE}
   - RecastDemo/Bin/Tests
   - make -C build -j$(nproc)
   - cd build && ctest

--- a/Recast/Include/RecastAlloc.h
+++ b/Recast/Include/RecastAlloc.h
@@ -172,7 +172,7 @@ bool rcVectorBase<T, H>::reserve(rcSizeType count) {
 }
 template <typename T, rcAllocHint H>
 T* rcVectorBase<T, H>::allocate_and_copy(rcSizeType size) {
-	rcAssert(RC_SIZE_MAX / sizeof(T) >= size);
+	rcAssert(RC_SIZE_MAX / static_cast<rcSizeType>(sizeof(T)) >= size);
 	T* new_data = static_cast<T*>(rcAlloc(sizeof(T) * size, H));
 	if (new_data) {
 		copy_range(new_data, m_data, m_data + m_size);

--- a/RecastDemo/CMakeLists.txt
+++ b/RecastDemo/CMakeLists.txt
@@ -1,12 +1,12 @@
 file(GLOB SOURCES Source/*.cpp Contrib/fastlz/fastlz.c)
 
-include(cmake/FindSDL2.cmake)
+LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 find_package(OpenGL REQUIRED)
 find_package(SDL2 REQUIRED)
 
 include_directories(SYSTEM ${OPENGL_INCLUDE_DIR})
-include_directories(SYSTEM ${SDL2_INCLUDE_DIRS})
+include_directories(SYSTEM ${SDL2_INCLUDE_DIR})
 include_directories(SYSTEM Contrib/fastlz)
 include_directories(SYSTEM Contrib)
 include_directories(../DebugUtils/Include)

--- a/RecastDemo/Source/Sample_TileMesh.cpp
+++ b/RecastDemo/Source/Sample_TileMesh.cpp
@@ -224,24 +224,6 @@ void Sample_TileMesh::cleanup()
 	m_dmesh = 0;
 }
 
-
-static const int NAVMESHSET_MAGIC = 'M'<<24 | 'S'<<16 | 'E'<<8 | 'T'; //'MSET';
-static const int NAVMESHSET_VERSION = 1;
-
-struct NavMeshSetHeader
-{
-	int magic;
-	int version;
-	int numTiles;
-	dtNavMeshParams params;
-};
-
-struct NavMeshTileHeader
-{
-	dtTileRef tileRef;
-	int dataSize;
-};
-
 void Sample_TileMesh::handleSettings()
 {
 	Sample::handleCommonSettings();

--- a/RecastDemo/premake5.lua
+++ b/RecastDemo/premake5.lua
@@ -11,16 +11,14 @@ solution "recastnavigation"
 		"Debug",
 		"Release"
 	}
+
 	location (todir)
 
-	-- extra warnings, no exceptions or rtti
-	flags { 
-		"ExtraWarnings",
-		"FloatFast",
-		"Symbols"
-	}
+	floatingpoint "Fast"
+	symbols "On"
 	exceptionhandling "Off"
 	rtti "Off"
+	flags { "FatalCompileWarnings" }
 
 	-- debug configs
 	configuration "Debug*"
@@ -30,19 +28,20 @@ solution "recastnavigation"
  	-- release configs
 	configuration "Release*"
 		defines { "NDEBUG" }
-		flags { "Optimize" }
+		optimize "On"
 		targetdir ( todir .. "/lib/Release" )
+
+	configuration "not windows"
+		warnings "Extra"
 
 	-- windows specific
 	configuration "windows"
 		defines { "WIN32", "_WINDOWS", "_CRT_SECURE_NO_WARNINGS", "_HAS_EXCEPTIONS=0" }
-
-	-- linux specific
-	configuration { "linux", "gmake" }
-		buildoptions {
-			"-Wall",
-			"-Werror"
-		}
+		-- warnings "Extra" uses /W4 which is too aggressive for us, so use W3 instead.
+		-- Disable:
+		-- * C4351: new behavior for array initialization
+		-- * C4291: no matching operator delete found; we don't use exceptions, so doesn't matter
+		buildoptions { "/W3", "/wd4351", "/wd4291" }
 
 project "DebugUtils"
 	language "C++"
@@ -171,7 +170,6 @@ project "RecastDemo"
 	configuration { "macosx" }
 		kind "ConsoleApp" -- xcode4 failes to run the project if using WindowedApp
 		includedirs { "/Library/Frameworks/SDL2.framework/Headers" }
-		buildoptions { "-Wunused-value -Wshadow -Wreorder -Wsign-compare -Wall" }
 		links { 
 			"OpenGL.framework", 
 			"SDL2.framework",
@@ -248,7 +246,6 @@ project "Tests"
 	configuration { "macosx" }
 		kind "ConsoleApp"
 		includedirs { "/Library/Frameworks/SDL2.framework/Headers" }
-		buildoptions { "-Wunused-value -Wshadow -Wreorder -Wsign-compare -Wall" }
 		links { 
 			"OpenGL.framework", 
 			"SDL2.framework",

--- a/Tests/Detour/Tests_Detour.cpp
+++ b/Tests/Detour/Tests_Detour.cpp
@@ -16,18 +16,18 @@ TEST_CASE("dtRandomPointInConvexPoly")
 		float out[3];
 
 		dtRandomPointInConvexPoly(pts, npts, areas, 0.0f, 1.0f, out);
-		REQUIRE(out[0] == 0);
-		REQUIRE(out[1] == 0);
-		REQUIRE(out[2] == 1);
+		REQUIRE(out[0] == Approx(0));
+		REQUIRE(out[1] == Approx(0));
+		REQUIRE(out[2] == Approx(1));
 
 		dtRandomPointInConvexPoly(pts, npts, areas, 0.5f, 1.0f, out);
-		REQUIRE(out[0] == 1.0f / 2);
-		REQUIRE(out[1] == 0);
-		REQUIRE(out[2] == 1.0f / 2);
+		REQUIRE(out[0] == Approx(1.0f / 2));
+		REQUIRE(out[1] == Approx(0));
+		REQUIRE(out[2] == Approx(1.0f / 2));
 
 		dtRandomPointInConvexPoly(pts, npts, areas, 1.0f, 1.0f, out);
-		REQUIRE(out[0] == 1);
-		REQUIRE(out[1] == 0);
-		REQUIRE(out[2] == 0);
+		REQUIRE(out[0] == Approx(1));
+		REQUIRE(out[1] == Approx(0));
+		REQUIRE(out[2] == Approx(0));
 	}
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,17 +1,21 @@
 shallow_clone: true
 
-os:
-  - Visual Studio 2015
-
 environment:
   matrix:
-  - TOOLSET: vs2010
-  - TOOLSET: vs2013
-  - TOOLSET: vs2015
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+      PREMAKE_ACTION: vs2013
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      PREMAKE_ACTION: vs2015
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      PREMAKE_ACTION: vs2017
+
+configuration:
+  - Debug
+  - Release
 
 install:
   # Download Premake
-  - ps: Start-FileDownload 'https://github.com/premake/premake-core/releases/download/v5.0.0-alpha7/premake-5.0.0-alpha7-windows.zip' 'premake.zip'
+  - ps: Start-FileDownload 'https://github.com/premake/premake-core/releases/download/v5.0.0-alpha12/premake-5.0.0-alpha12-windows.zip' 'premake.zip'
   
   # Extract it in-place; premake5.exe is at the top level.
   - 7z x premake.zip
@@ -23,14 +27,11 @@ install:
   - cd RecastDemo\Contrib && 7z x SDL.zip && ren SDL2-2.0.4 SDL && cd ..\..
   
   # Generate solution files using premake.
-  - cd RecastDemo && "../premake5.exe" %TOOLSET% && cd ..
+  - cd RecastDemo && "../premake5.exe" %PREMAKE_ACTION% && cd ..
 
-configuration:
-  - Debug
-  - Release
 
 build:
-  project: RecastDemo/Build/$(TOOLSET)/recastnavigation.sln
+  project: RecastDemo/Build/$(PREMAKE_ACTION)/recastnavigation.sln
 
 after_test:
   - RecastDemo\Bin\Tests.exe


### PR DESCRIPTION
Adds Clang and VS2017 to CI, and ensures that they are treating warnings as errors. Also fixes the new warnings that cause build break, including #334.