### PR TITLE
Island system

### DIFF
--- a/Detour/Include/DetourIslandSystem.h
+++ b/Detour/Include/DetourIslandSystem.h
@@ -1,0 +1,54 @@
+//
+// Copyright (c) 2009-2010 Mikko Mononen memon@inside.org
+// Dmitrii Shkarovskii scriper.proger@gmail.com
+//
+// This software is provided 'as-is', without any express or implied
+// warranty.  In no event will the authors be held liable for any damages
+// arising from the use of this software.
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+// Use in quick check passability from one polygon to another polygon
+// This system works on compares polygon island indices
+// To activate this system you need uncomment define NAVMESH_ISLAND_SYSTEM 
+
+#ifndef DETOURISLANDSYSTEM_H
+#define DETOURISLANDSYSTEM_H
+
+#include <DetourNavMesh.h>
+#include <DetourNavMeshQuery.h>
+
+#ifdef NAVMESH_ISLAND_SYSTEM
+
+class dtIslandManager
+{
+public:
+	dtIslandManager(dtNavMesh* navMesh);
+
+	void splitMeshToIslands(const dtQueryFilter* filter);
+	void splitTileToIslands(const int x, const int y, const dtQueryFilter* filter);
+
+private:
+	void fillPolysWithIslandIdx(unsigned int fromIdx, unsigned int toIdx, bool force);
+	void splitTileToIslands(dtNavMeshQuery* query, dtPolyRef* nearestPolys, int tileNum, const dtMeshTile* tile, const dtQueryFilter* filter);
+	void resetIndexes();
+
+	dtNavMeshQuery* getQuery() const;
+	void freeQuery(dtNavMeshQuery* query) const;
+
+private:
+	unsigned int m_freeIslandIdx;
+	const dtNavMesh* m_navMesh;
+};
+#endif
+
+#endif // DETOURISLANDSYSTEM_H

--- a/Detour/Include/DetourNavMesh.h
+++ b/Detour/Include/DetourNavMesh.h
@@ -22,6 +22,9 @@
 #include "DetourAlloc.h"
 #include "DetourStatus.h"
 
+// Uncomment to enable navmesh island system
+//#define NAVMESH_ISLAND_SYSTEM
+
 // Undefine (or define in a build cofnig) the following line to use 64bit polyref.
 // Generally not needed, useful for very large worlds.
 // Note: tiles build using 32bit refs are not compatible with 64bit refs!
@@ -149,6 +152,12 @@ enum dtPolyTypes
 /// @ingroup detour
 struct dtPoly
 {
+	dtPoly()
+	{
+#ifdef NAVMESH_ISLAND_SYSTEM
+		islandIdx = 0;
+#endif
+	}
 	/// Index to first link in linked list. (Or #DT_NULL_LINK if there is no link.)
 	unsigned int firstLink;
 
@@ -161,6 +170,20 @@ struct dtPoly
 
 	/// The user defined polygon flags.
 	unsigned short flags;
+
+#ifdef NAVMESH_ISLAND_SYSTEM
+	/// The island index.
+	unsigned int islandIdx;
+
+	/// Gets island index
+	/// @return The island index.
+	inline unsigned int getIslandIdx() const { return islandIdx; }
+
+	/// Set island index
+	///  @param[in]	idx		The new island index.
+	inline void setIslandIdx(unsigned int idx) { islandIdx = idx; }
+
+#endif
 
 	/// The number of vertices in the polygon.
 	unsigned char vertCount;
@@ -592,6 +615,31 @@ public:
 	}
 
 	/// @}
+
+#ifdef NAVMESH_ISLAND_SYSTEM
+	/// @{
+	/// @name Island system
+
+	/// Gets the tile and polygon for the specified polygon reference.
+	///  @param[in]	startRef		The first reference first for the a polygon.
+	///  @param[in]	endRef			The second reference for the a polygon.
+	/// @return True if path exists
+	bool checkPathExists(const dtPolyRef startRef, const dtPolyRef endRef) const;
+
+	/// Gets the tile and polygon for the specified polygon reference.
+	///  @param[in]	ref		The reference for the a polygon.
+	///  @param[in]	idx		The new island index.
+	/// @return The status flags for the operation.
+	dtStatus setPolyIslandIdx(dtPolyRef ref, unsigned int idx);
+
+	/// Gets the tile and polygon for the specified polygon reference.
+	///  @param[in]  ref		The reference for the a polygon.
+	///  @param[out] idx		The island index.
+	/// @return The status flags for the operation.
+	dtStatus getPolyIslandIdx(dtPolyRef ref, unsigned int* idx) const;
+
+	/// @}
+#endif
 	
 private:
 	// Explicitly disabled copy constructor and copy assignment operator.
@@ -635,7 +683,7 @@ private:
 							dtPolyRef* polys, const int maxPolys) const;
 	/// Find nearest polygon within a tile.
 	dtPolyRef findNearestPolyInTile(const dtMeshTile* tile, const float* center,
-									const float* halfExtents, float* nearestPt) const;
+									const float* extents, float* nearestPt) const;
 	/// Returns closest point on polygon.
 	void closestPointOnPoly(dtPolyRef ref, const float* pos, float* closest, bool* posOverPoly) const;
 	

--- a/Detour/Source/DetourIslandSystem.cpp
+++ b/Detour/Source/DetourIslandSystem.cpp
@@ -1,0 +1,173 @@
+//
+// Copyright (c) 2009-2010 Mikko Mononen memon@inside.org
+// Dmitrii Shkarovskii scriper.proger@gmail.com
+//
+// This software is provided 'as-is', without any express or implied
+// warranty.  In no event will the authors be held liable for any damages
+// arising from the use of this software.
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#include "DetourIslandSystem.h"
+#include "DetourCommon.h"
+
+#ifdef NAVMESH_ISLAND_SYSTEM
+
+#define ISLAND_FIND_POLYS_COUNT_MAX 300
+#define ISLAND_CHECK_RADIUS 100.0f
+#define ISLAND_QUERY_POLYS_MAX 65500
+
+dtIslandManager::dtIslandManager(dtNavMesh* navMesh) :
+	m_freeIslandIdx(0),
+	m_navMesh(navMesh)
+{
+	resetIndexes();
+}
+
+void dtIslandManager::resetIndexes()
+{
+	m_freeIslandIdx = 1;
+}
+
+dtNavMeshQuery* dtIslandManager::getQuery() const
+{
+	dtNavMeshQuery* query = dtAllocNavMeshQuery(); 
+	query->init(m_navMesh, ISLAND_QUERY_POLYS_MAX);
+	return query;
+}
+
+void dtIslandManager::freeQuery(dtNavMeshQuery* query) const
+{
+	dtFreeNavMeshQuery(query);
+}
+
+void dtIslandManager::splitMeshToIslands(const dtQueryFilter* filter)
+{
+	resetIndexes();
+
+	fillPolysWithIslandIdx(0, 0, true);
+	dtNavMeshQuery* query = getQuery();
+	if (query)
+	{
+		dtPolyRef nearestPolys[ISLAND_QUERY_POLYS_MAX];
+		for (int tileNum = 0; tileNum < m_navMesh->getMaxTiles(); tileNum++)
+		{
+			const dtMeshTile* tile = m_navMesh->getTile(tileNum);
+			if (!tile || !tile->header)
+				continue;
+
+			splitTileToIslands(query, nearestPolys, tileNum, tile, filter);
+		}
+		freeQuery(query);
+	}
+}
+
+void dtIslandManager::splitTileToIslands(const int x, const int y, const dtQueryFilter* filter)
+{
+	const dtTileRef tileRef = m_navMesh->getTileRefAt(x, y, 0);
+	const int tileNum = m_navMesh->decodePolyIdTile(tileRef);
+	const dtMeshTile* tile = m_navMesh->getTile(tileNum);
+	if (tile)
+	{
+		if (tile->header)
+		{
+			dtNavMeshQuery* query = getQuery();
+			if (query)
+			{
+				dtPolyRef nearestPolys[ISLAND_QUERY_POLYS_MAX];
+				splitTileToIslands(query, nearestPolys, tileNum, tile, filter);
+				freeQuery(query);
+			}
+		}
+	}
+}
+
+void dtIslandManager::fillPolysWithIslandIdx(unsigned int fromIdx, unsigned int toIdx, bool force)
+{
+	for (int tileNum = 0; tileNum < m_navMesh->getMaxTiles(); tileNum++)
+	{
+		const dtMeshTile* tile = m_navMesh->getTile(tileNum);
+		if (!tile || !tile->header)
+			continue;
+
+		for (int polyNum = 0; polyNum < tile->header->polyCount; polyNum++)
+		{
+			dtPoly* poly = &(tile->polys)[polyNum];
+			if (!poly)
+				continue;
+			if (force || poly->getIslandIdx() == fromIdx)
+				poly->setIslandIdx(toIdx);
+		}
+	}
+}
+
+void dtIslandManager::splitTileToIslands(dtNavMeshQuery* query, dtPolyRef* nearestPolys, int tileNum, const dtMeshTile* tile, const dtQueryFilter* filter)
+{
+	for (int polyNum = 0; polyNum < tile->header->polyCount; polyNum++)
+	{
+		dtPoly* poly = &(tile->polys)[polyNum];
+		if (!poly)
+			continue;
+
+		if (poly->getType() == DT_POLYTYPE_OFFMESH_CONNECTION) // Skip off-mesh links.
+			continue;
+
+		if (poly->getIslandIdx() == 0) // If poly have not island index
+		{
+			dtPolyRef polyRef = m_navMesh->encodePolyId(tile->salt, tileNum, polyNum);
+			float c[3];
+
+			const dtMeshTile* tile = 0;
+			const dtPoly* poly = 0;
+			dtStatus status = m_navMesh->getTileAndPolyByRef(polyRef, &tile, &poly);
+			if (!dtStatusFailed(status))
+				dtCalcPolyCenter(c, poly->verts, (int)poly->vertCount, tile->verts);
+
+			int findCount = 0;
+			query->findPolysAroundCircle(polyRef, c, ISLAND_CHECK_RADIUS, filter, nearestPolys, 0, 0, &findCount, ISLAND_FIND_POLYS_COUNT_MAX); // Find nearest
+
+			int isladIndex = 0;
+			for (int i = 0; i < findCount; i++) // Find poly with island index
+			{
+				unsigned int islandCheckIndex = 0;
+				m_navMesh->getPolyIslandIdx(nearestPolys[i], &islandCheckIndex);
+				if (islandCheckIndex != 0)
+				{
+					isladIndex = islandCheckIndex;
+					break;
+				}
+			}
+
+			if (isladIndex == 0) // If not find then generate new index
+			{
+				isladIndex = m_freeIslandIdx;
+				m_freeIslandIdx++;
+				if (m_freeIslandIdx <= 0)
+					m_freeIslandIdx = 1;
+			}
+
+			((dtPoly*)poly)->setIslandIdx(isladIndex); // Set island index
+
+			for (int i = 0; i < findCount; i++)
+			{
+				const dtPolyRef nearestPoly = nearestPolys[i];
+				unsigned int islandCheckIndex = 0;
+				m_navMesh->getPolyIslandIdx(nearestPoly, &islandCheckIndex);
+				if (islandCheckIndex != 0 && islandCheckIndex != isladIndex) 
+					fillPolysWithIslandIdx(islandCheckIndex, isladIndex, false); // Merge islands
+				else
+					((dtNavMesh*)m_navMesh)->setPolyIslandIdx(nearestPoly, isladIndex);
+			}
+		}
+	}
+}
+#endif


### PR DESCRIPTION
Island system: use in quick check passability from one polygon to another polygon (This system works on compares polygon island indices). 

To activate this system you need uncomment define NAVMESH_ISLAND_SYSTEM in file: "DetourNavMesh.h".
To split a mesh into islands you must use a class dtIslandManager in the file: "DetourNavMesh.h".


