### PR TITLE
allow third-party code to define its own assert definitions

### DIFF
--- a/Detour/Include/DetourAssert.h
+++ b/Detour/Include/DetourAssert.h
@@ -22,12 +22,7 @@
 // Note: This header file's only purpose is to include define assert.
 // Feel free to change the file and include your own implementation instead.
 
-#ifdef NDEBUG
-// From http://cnicholson.net/2009/02/stupid-c-tricks-adventures-in-assert/
-#	define dtAssert(x) do { (void)sizeof(x); } while((void)(__LINE__==-1),false)  
-#else
-#	include <assert.h> 
-#	define dtAssert assert
-#endif
+#include "common/Common.h"
+#define dtAssert DAEMON_ASSERT
 
 #endif // DETOURASSERT_H

--- a/Detour/Include/DetourAssert.h
+++ b/Detour/Include/DetourAssert.h
@@ -22,12 +22,16 @@
 // Note: This header file's only purpose is to include define assert.
 // Feel free to change the file and include your own implementation instead.
 
-#ifdef NDEBUG
+// Define dtAssert if there is no user-supplied definition.
+// Note that if there is a user-supplied definition, it is used even if NDEBUG is defined.
+#ifndef dtAssert
+#	ifdef NDEBUG
 // From http://cnicholson.net/2009/02/stupid-c-tricks-adventures-in-assert/
-#	define dtAssert(x) do { (void)sizeof(x); } while((void)(__LINE__==-1),false)  
-#else
-#	include <assert.h> 
-#	define dtAssert assert
-#endif
+#		define dtAssert(x) do { (void)sizeof(x); } while((void)(__LINE__==-1),false)
+#	else
+#		include <assert.h>
+#		define dtAssert assert
+#	endif
+#endif // ifndef dtAssert
 
 #endif // DETOURASSERT_H

--- a/Detour/Include/DetourAssert.h
+++ b/Detour/Include/DetourAssert.h
@@ -22,7 +22,12 @@
 // Note: This header file's only purpose is to include define assert.
 // Feel free to change the file and include your own implementation instead.
 
-#include "common/Common.h"
-#define dtAssert DAEMON_ASSERT
+#ifdef NDEBUG
+// From http://cnicholson.net/2009/02/stupid-c-tricks-adventures-in-assert/
+#	define dtAssert(x) do { (void)sizeof(x); } while((void)(__LINE__==-1),false)  
+#else
+#	include <assert.h> 
+#	define dtAssert assert
+#endif
 
 #endif // DETOURASSERT_H

--- a/Recast/Include/RecastAssert.h
+++ b/Recast/Include/RecastAssert.h
@@ -22,12 +22,7 @@
 // Note: This header file's only purpose is to include define assert.
 // Feel free to change the file and include your own implementation instead.
 
-#ifdef NDEBUG
-// From http://cnicholson.net/2009/02/stupid-c-tricks-adventures-in-assert/
-#	define rcAssert(x) do { (void)sizeof(x); } while((void)(__LINE__==-1),false)  
-#else
-#	include <assert.h> 
-#	define rcAssert assert
-#endif
+#include "common/Common.h"
+#define rcAssert DAEMON_ASSERT
 
 #endif // RECASTASSERT_H

--- a/Recast/Include/RecastAssert.h
+++ b/Recast/Include/RecastAssert.h
@@ -22,7 +22,12 @@
 // Note: This header file's only purpose is to include define assert.
 // Feel free to change the file and include your own implementation instead.
 
-#include "common/Common.h"
-#define rcAssert DAEMON_ASSERT
+#ifdef NDEBUG
+// From http://cnicholson.net/2009/02/stupid-c-tricks-adventures-in-assert/
+#	define rcAssert(x) do { (void)sizeof(x); } while((void)(__LINE__==-1),false)  
+#else
+#	include <assert.h> 
+#	define rcAssert assert
+#endif
 
 #endif // RECASTASSERT_H

--- a/Recast/Include/RecastAssert.h
+++ b/Recast/Include/RecastAssert.h
@@ -22,12 +22,16 @@
 // Note: This header file's only purpose is to include define assert.
 // Feel free to change the file and include your own implementation instead.
 
-#ifdef NDEBUG
+// Define rcAssert if there is no user-supplied definition.
+// Note that if there is a user-supplied definition, it is used even if NDEBUG is defined.
+#ifndef rcAssert
+#	ifdef NDEBUG
 // From http://cnicholson.net/2009/02/stupid-c-tricks-adventures-in-assert/
-#	define rcAssert(x) do { (void)sizeof(x); } while((void)(__LINE__==-1),false)  
-#else
-#	include <assert.h> 
-#	define rcAssert assert
-#endif
+#		define rcAssert(x) do { (void)sizeof(x); } while((void)(__LINE__==-1),false)
+#	else
+#		include <assert.h>
+#		define rcAssert assert
+#	endif
+#endif // ifndef rcAssert
 
 #endif // RECASTASSERT_H


### PR DESCRIPTION
The idea is to allow third-party code like Dæmon engine to define `dtAssert` and `rcAssert` as something custom (like `DAEMON_ASSERT`) and to patch Dæmon to customize those definitions on its side. If it works and if it's OK, I'll try to upstream the Detour/Recast patch so we can drop our custom _recastnavigation_ fork.