### PR TITLE
Allow to use recastnavigation by find_package and add_subdirectory

### DIFF
--- a/DebugUtils/CMakeLists.txt
+++ b/DebugUtils/CMakeLists.txt
@@ -1,19 +1,21 @@
 file(GLOB SOURCES Source/*.cpp)
 
-include_directories(../Recast/Include)
-include_directories(../Detour/Include)
-include_directories(../DetourTileCache/Include)
-include_directories(Include)
-
 if (RECASTNAVIGATION_STATIC)
     add_library(DebugUtils STATIC ${SOURCES})
 else()
     add_library(DebugUtils SHARED ${SOURCES})
 endif()
 
+set(DebugUtils_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Include")
+
+target_include_directories(DebugUtils PUBLIC
+    "$<BUILD_INTERFACE:${DebugUtils_INCLUDE_DIR}>"
+)
+
 target_link_libraries(DebugUtils
     Recast
     Detour
+    DetourTileCache
 )
 
 set_target_properties(DebugUtils PROPERTIES

--- a/DebugUtils/CMakeLists.txt
+++ b/DebugUtils/CMakeLists.txt
@@ -6,6 +6,8 @@ else()
     add_library(DebugUtils SHARED ${SOURCES})
 endif()
 
+add_library(RecastNavigation::DebugUtils ALIAS DebugUtils)
+
 set(DebugUtils_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Include")
 
 target_include_directories(DebugUtils PUBLIC

--- a/Detour/CMakeLists.txt
+++ b/Detour/CMakeLists.txt
@@ -6,6 +6,8 @@ else()
     add_library(Detour SHARED ${SOURCES})
 endif()
 
+add_library(RecastNavigation::Detour ALIAS Detour)
+
 set(Detour_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Include")
 
 target_include_directories(Detour PUBLIC

--- a/Detour/CMakeLists.txt
+++ b/Detour/CMakeLists.txt
@@ -1,12 +1,16 @@
 file(GLOB SOURCES Source/*.cpp)
 
-include_directories(Include)
-
 if(RECASTNAVIGATION_STATIC)
     add_library(Detour STATIC ${SOURCES})
 else()
     add_library(Detour SHARED ${SOURCES})
 endif()
+
+set(Detour_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Include")
+
+target_include_directories(Detour PUBLIC
+    "$<BUILD_INTERFACE:${Detour_INCLUDE_DIR}>"
+)
 
 set_target_properties(Detour PROPERTIES
         SOVERSION ${SOVERSION}

--- a/DetourCrowd/CMakeLists.txt
+++ b/DetourCrowd/CMakeLists.txt
@@ -1,13 +1,16 @@
 file(GLOB SOURCES Source/*.cpp)
 
-include_directories(../Detour/Include)
-include_directories(Include)
-
 if (RECASTNAVIGATION_STATIC)
     add_library(DetourCrowd STATIC ${SOURCES})
 else ()
     add_library(DetourCrowd SHARED ${SOURCES})
 endif ()
+
+set(DetourCrowd_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Include")
+
+target_include_directories(DetourCrowd PUBLIC
+    "$<BUILD_INTERFACE:${DetourCrowd_INCLUDE_DIR}>"
+)
 
 target_link_libraries(DetourCrowd
     Detour

--- a/DetourCrowd/CMakeLists.txt
+++ b/DetourCrowd/CMakeLists.txt
@@ -6,6 +6,8 @@ else ()
     add_library(DetourCrowd SHARED ${SOURCES})
 endif ()
 
+add_library(RecastNavigation::DetourCrowd ALIAS DetourCrowd)
+
 set(DetourCrowd_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Include")
 
 target_include_directories(DetourCrowd PUBLIC

--- a/DetourTileCache/CMakeLists.txt
+++ b/DetourTileCache/CMakeLists.txt
@@ -6,6 +6,8 @@ else ()
     add_library(DetourTileCache SHARED ${SOURCES})
 endif ()
 
+add_library(RecastNavigation::DetourTileCache ALIAS DetourTileCache)
+
 set(DetourTileCache_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Include")
 
 target_include_directories(DetourTileCache PUBLIC

--- a/DetourTileCache/CMakeLists.txt
+++ b/DetourTileCache/CMakeLists.txt
@@ -1,13 +1,16 @@
 file(GLOB SOURCES Source/*.cpp)
 
-include_directories(../Detour/Include)
-include_directories(Include)
-
 if (RECASTNAVIGATION_STATIC)
     add_library(DetourTileCache STATIC ${SOURCES})
 else ()
     add_library(DetourTileCache SHARED ${SOURCES})
 endif ()
+
+set(DetourTileCache_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Include")
+
+target_include_directories(DetourTileCache PUBLIC
+    "$<BUILD_INTERFACE:${DetourTileCache_INCLUDE_DIR}>"
+)
 
 target_link_libraries(DetourTileCache
     Detour

--- a/Recast/CMakeLists.txt
+++ b/Recast/CMakeLists.txt
@@ -1,12 +1,16 @@
 file(GLOB SOURCES Source/*.cpp)
 
-include_directories(Include)
-
 if (RECASTNAVIGATION_STATIC)
     add_library(Recast STATIC ${SOURCES})
 else ()
     add_library(Recast SHARED ${SOURCES})
 endif ()
+
+set(Recast_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Include")
+
+target_include_directories(Recast PUBLIC
+    "$<BUILD_INTERFACE:${Recast_INCLUDE_DIR}>"
+)
 
 set_target_properties(Recast PROPERTIES
         SOVERSION ${SOVERSION}

--- a/Recast/CMakeLists.txt
+++ b/Recast/CMakeLists.txt
@@ -6,6 +6,8 @@ else ()
     add_library(Recast SHARED ${SOURCES})
 endif ()
 
+add_library(RecastNavigation::Recast ALIAS Recast)
+
 set(Recast_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Include")
 
 target_include_directories(Recast PUBLIC


### PR DESCRIPTION
* When use `add_subdirectory` it is no more required to say cmake where to find include directories. 
* Allow to use cmake namespace `RecastNavigation` to link libraries. Ex:
```cmake
target_link_libraries(myapp
    RecastNavigation::DebugUtils
    RecastNavigation::Detour
    RecastNavigation::Recast
)
```