### PR TITLE
Use SDL2.dll path relative to script file

### DIFF
--- a/RecastDemo/premake5.lua
+++ b/RecastDemo/premake5.lua
@@ -170,7 +170,7 @@ project "RecastDemo"
 		}
 		postbuildcommands {
 			-- Copy the SDL2 dll to the Bin folder.
-			'{COPY} "%{wks.location}../../Contrib/SDL/lib/%{cfg.architecture:gsub("x86_64", "x64")}/SDL2.dll" "%{cfg.targetdir}"'
+			'{COPY} "%{path.getabsolute("Contrib/SDL/lib/" .. cfg.architecture:gsub("x86_64", "x64") .. "/SDL2.dll")}" "%{cfg.targetdir}"'
 		}
 
 	-- mac includes and libs


### PR DESCRIPTION
Previously this was relative to the output file. This works around a
premake5 bug (https://github.com/premake/premake-core/issues/1186) and as a bonus makes it easier to support out-of-source builds with premake.