### PR TITLE
Add a matching placement delete for placement new

### DIFF
--- a/Recast/Include/RecastAlloc.h
+++ b/Recast/Include/RecastAlloc.h
@@ -66,6 +66,7 @@ void rcFree(void* ptr);
 /// and STL.
 struct rcNewTag {};
 inline void* operator new(size_t, const rcNewTag&, void* p) { return p; }
+inline void operator delete(void*, const rcNewTag&, void*) {}
 
 /// Signed to avoid warnnings when comparing to int loop indexes, and common error with comparing to zero.
 /// MSVC2010 has a bug where ssize_t is unsigned (!!!).

--- a/RecastDemo/premake5.lua
+++ b/RecastDemo/premake5.lua
@@ -41,8 +41,7 @@ solution "recastnavigation"
 		-- warnings "Extra" uses /W4 which is too aggressive for us, so use W3 instead.
 		-- Disable:
 		-- * C4351: new behavior for array initialization
-		-- * C4291: no matching operator delete found; we don't use exceptions, so doesn't matter
-		buildoptions { "/W3", "/wd4351", "/wd4291" }
+		buildoptions { "/W3", "/wd4351" }
 
 	filter "platforms:Win32"
 		architecture "x32"


### PR DESCRIPTION
Even though it is a no-op this is good style and avoids a warning with
MSVC.

Fix #359