### PR TITLE
Use Travis-CI Matrix to add more type of builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,65 @@
-sudo: false
-
 language: cpp
+branches:
+  only:
+  - master
+  - coverity_scan
+  - /openmw-.*$/
 
-# Build with gcc and clang.
-compiler:
-  - gcc
-  - clang
-
-# Build both debug and release configurations, through use of an environment variable in the build matrix.
-env:
-  - BUILD_TYPE=debug CMAKE_BUILD_TYPE=Debug
-  - BUILD_TYPE=release CMAKE_BUILD_TYPE=Release
+sudo: false
 
 addons:
   apt:
-    packages:
-      - libsdl2-dev
+    sources:
+      - ubuntu-toolchain-r-test
+      - llvm-toolchain-xenial-7
+    packages: [ cmake, clang-7, clang-tools-7, gcc-8, g++-8, libsdl2-dev ]
 
-install:
-  - wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha12/premake-5.0.0-alpha12-linux.tar.gz -O premake.tar.gz
-  - tar -xf premake.tar.gz
-  - rm premake.tar.gz
+matrix:
+  include:
+  - name: OpenMW (all) on MacOS xcode9.4
+    os: osx
+    osx_image: xcode9.4
+    if: branch != coverity_scan
+  - name: OpenMW (all) on Ubuntu Xenial GCC-5
+    os: linux
+    dist: xenial
+    sudo: required
+    if: branch != coverity_scan
+  - name: OpenMW (all) on Ubuntu Xenial GCC-8
+    os: linux
+    dist: xenial
+    sudo: required
+    env:
+    - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
+    if: branch != coverity_scan
+  - name: OpenMW (openmw) on Ubuntu Xenial Clang-7 with Static Analysis
+    os: linux
+    dist: xenial
+    sudo: required
+    env:
+    - MATRIX_EVAL="CC=clang-7 && CXX=clang++-7"
+    - ANALYZE="scan-build-7 --force-analyze-debug-code --use-cc clang-7 --use-c++ clang++-7"
+    if: branch != coverity_scan
+    compiler: clang
+  - name: OpenMW (openmw-cs) on Ubuntu Xenial Clang-7 with Static Analysis
+    os: linux
+    dist: xenial
+    sudo: required
+    env:
+    - MATRIX_EVAL="CC=clang-7 && CXX=clang++-7"
+    - ANALYZE="scan-build-7 --force-analyze-debug-code --use-cc clang-7 --use-c++ clang++-7"
+    if: branch != coverity_scan
+    compiler: clang
+  - name: OpenMW Components Coverity Scan
+    os: linux
+    dist: xenial
+    sudo: required
+    if: branch = coverity_scan
 
-# Run premake to generate makefiles.
-# Have to cd into directory and back out since premake5 doesn't appear to accept a directory argument.
-before_script:
-  - cd RecastDemo && ../premake5 gmake && cd ..
-  - mkdir build && cd build && cmake -D CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} .. && cd ..
+before_install:
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then eval "${MATRIX_EVAL}"; fi
 
-# Run make in the directory containing generated makefiles, on the configuration specified by the environment variable.
 script:
-  - make -C RecastDemo/Build/gmake -j$(nproc) config=${BUILD_TYPE}
-  - RecastDemo/Bin/Tests
-  - make -C build -j$(nproc)
-  - cd build && ctest
+  - mkdir -p build; cd ./build
+  - ${ANALYZE} cmake ../
+  - make -j3

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,44 +19,38 @@ matrix:
   - name: OpenMW (all) on MacOS xcode9.4
     os: osx
     osx_image: xcode9.4
+    before_install:
+      - brew update
+      - brew install sdl2
     if: branch != coverity_scan
-  - name: OpenMW (all) on Ubuntu Xenial GCC-5
+  - name: Recastnavigation on Ubuntu Xenial GCC-5
     os: linux
     dist: xenial
     sudo: required
     if: branch != coverity_scan
-  - name: OpenMW (all) on Ubuntu Xenial GCC-8
-    os: linux
-    dist: xenial
-    sudo: required
-    env:
-    - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
-    if: branch != coverity_scan
-  - name: OpenMW (openmw) on Ubuntu Xenial Clang-7 with Static Analysis
+  - name: Recastnavigation on Ubuntu Xenial GCC-8
     os: linux
     dist: xenial
     sudo: required
     env:
-    - MATRIX_EVAL="CC=clang-7 && CXX=clang++-7"
-    - ANALYZE="scan-build-7 --force-analyze-debug-code --use-cc clang-7 --use-c++ clang++-7"
+      - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
+    if: branch != coverity_scan
+  - name: Recastnavigation on Ubuntu Xenial Clang-7 with Static Analysis
+    os: linux
+    dist: xenial
+    sudo: required
+    env:
+      - MATRIX_EVAL="CC=clang-7 && CXX=clang++-7"
+      - ANALYZE="scan-build-7 --force-analyze-debug-code --use-cc clang-7 --use-c++ clang++-7"
     if: branch != coverity_scan
     compiler: clang
-  - name: OpenMW (openmw-cs) on Ubuntu Xenial Clang-7 with Static Analysis
-    os: linux
-    dist: xenial
-    sudo: required
-    env:
-    - MATRIX_EVAL="CC=clang-7 && CXX=clang++-7"
-    - ANALYZE="scan-build-7 --force-analyze-debug-code --use-cc clang-7 --use-c++ clang++-7"
-    if: branch != coverity_scan
-    compiler: clang
-  - name: OpenMW Components Coverity Scan
+  - name: Recastnavigation Coverity Scan
     os: linux
     dist: xenial
     sudo: required
     if: branch = coverity_scan
 
-before_install:
+before_script:
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then eval "${MATRIX_EVAL}"; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,16 @@ matrix:
     env:
       - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
     if: branch != coverity_scan
+  - name: Recastnavigation on Ubuntu Xenial GCC-5 using Premake5
+    os: linux
+    dist: xenial
+    sudo: required
+    if: branch != coverity_scan
+    before_install:
+      - wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha12/premake-5.0.0-alpha12-linux.tar.gz -O premake.tar.gz
+      - tar -xf premake.tar.gz
+    env:
+      - PREMAKE=1
   - name: Recastnavigation on Ubuntu Xenial Clang-7 with Static Analysis
     os: linux
     dist: xenial
@@ -52,8 +62,10 @@ matrix:
 
 before_script:
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then eval "${MATRIX_EVAL}"; fi
+  - if [ "${PREMAKE}" = "1" ]; then cd RecastDemo && ../premake5 gmake; fi
+  - if [ "${PREMAKE}" != "1" ]; then mkdir -p build && cd build && ${ANALYZE} cmake ../; fi
 
 script:
-  - mkdir -p build; cd ./build
-  - ${ANALYZE} cmake ../
-  - make -j3
+  - make -j3  # 2 CPUs on Travis-CI + 1 extra for IO bound process
+  - if [ "${PREMAKE}" = "1" ]; then Bin/Tests; fi
+  - if [ "${PREMAKE}" != "1" ]; then ctest; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ branches:
   only:
   - master
   - coverity_scan
-  - /openmw-.*$/
+  - /recast-.*$/
 
 sudo: false
 
@@ -16,7 +16,7 @@ addons:
 
 matrix:
   include:
-  - name: OpenMW (all) on MacOS xcode9.4
+  - name: Recastnavigation (all) on MacOS xcode9.4
     os: osx
     osx_image: xcode9.4
     before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,10 +62,11 @@ matrix:
 
 before_script:
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then eval "${MATRIX_EVAL}"; fi
-  - if [ "${PREMAKE}" = "1" ]; then cd RecastDemo && ../premake5 gmake; fi
-  - if [ "${PREMAKE}" != "1" ]; then mkdir -p build && cd build && ${ANALYZE} cmake ../; fi
+  - if [ "${PREMAKE}" = "1" ]; then cd RecastDemo && ../premake5 gmake && cd ..; fi
+  - if [ "${PREMAKE}" != "1" ]; then mkdir -p build && cd build && ${ANALYZE} cmake ../ && cd ..; fi
 
-script:
-  - make -j3  # 2 CPUs on Travis-CI + 1 extra for IO bound process
-  - if [ "${PREMAKE}" = "1" ]; then Bin/Tests; fi
-  - if [ "${PREMAKE}" != "1" ]; then ctest; fi
+script:  # 2 CPUs on Travis-CI + 1 extra for IO bound process
+  - if [ "${PREMAKE}" = "1" ]; then make -C RecastDemo/Build/gmake -j3; fi
+  - if [ "${PREMAKE}" != "1" ]; then make -C build -j3; fi
+  - if [ "${PREMAKE}" = "1" ]; then RecastDemo/Bin/Tests; fi
+  - if [ "${PREMAKE}" != "1" ]; then cd build && ctest; fi

--- a/RecastDemo/CMakeLists.txt
+++ b/RecastDemo/CMakeLists.txt
@@ -40,7 +40,7 @@ target_link_libraries(RecastDemo ${OPENGL_LIBRARIES} SDL2::SDL2main DebugUtils D
 
 install(TARGETS RecastDemo
         RUNTIME DESTINATION bin
-        BUNDLE	DESTINATION bin)
+        BUNDLE DESTINATION bin)
 install(DIRECTORY Bin/Meshes DESTINATION bin)
 install(DIRECTORY Bin/TestCases DESTINATION bin)
 install(FILES Bin/DroidSans.ttf DESTINATION bin)

--- a/RecastDemo/CMakeLists.txt
+++ b/RecastDemo/CMakeLists.txt
@@ -38,7 +38,9 @@ endif()
 add_dependencies(RecastDemo DebugUtils Detour DetourCrowd DetourTileCache Recast)
 target_link_libraries(RecastDemo ${OPENGL_LIBRARIES} SDL2::SDL2main DebugUtils Detour DetourCrowd DetourTileCache Recast)
 
-install(TARGETS RecastDemo RUNTIME DESTINATION bin)
+install(TARGETS RecastDemo
+        RUNTIME DESTINATION bin
+        BUNDLE	DESTINATION bin)
 install(DIRECTORY Bin/Meshes DESTINATION bin)
 install(DIRECTORY Bin/TestCases DESTINATION bin)
 install(FILES Bin/DroidSans.ttf DESTINATION bin)


### PR DESCRIPTION
This gives Recastnavigation coverage in the following areas:
- MacOS (Xcode)
- Ubuntu Xenial (GCC-5)
- Ubuntu Xenial (GCC-8)
- Ubuntu Xenial (Clang-7 w/ Static Analysis)
- Coverity Scan (preparation work, not yet turned on)

All of this is done via CMake. I still need to add another build that uses premake5 so that there is coverage there as well.