### PR TITLE
Add guard check against infinite loop in detour.

### DIFF
--- a/Detour/Source/DetourNavMeshQuery.cpp
+++ b/Detour/Source/DetourNavMeshQuery.cpp
@@ -1208,6 +1208,9 @@ dtStatus dtNavMeshQuery::getPathToNode(dtNode* endNode, dtPolyRef* path, int* pa
 	int length = 0;
 	do
 	{
+		// Go through the whole m_nodepool max once, otherwise it's most likely a sign of infinite loop
+		if (length > m_nodePool->getMaxNodes())
+			return DT_FAILURE;
 		length++;
 		curNode = m_nodePool->getNodeAtIdx(curNode->pidx);
 	} while (curNode);


### PR DESCRIPTION
Add a guard check against infinite loop occurring in detour, happening when there is a circular reference in m_nodePool, i.e. A -> B -> C -> A.

While this might be caused by another issue in the code, it's better to just fail the path instead of entering an infinite loop.

As every node has only 1 reference to another node, the max number of iteration we can do before we are sure we are in an infinite loop is m_nodePool->getMaxNodes() . This also ensures that we don't accidentally exit too early for huge m_nodePool sizes.

Tested this code in a project where we have been experiencing this issue after upgrading from https://github.com/recastnavigation/recastnavigation/commit/2c85309280dbc9c82029e7ab16dfb01b9235c74e to https://github.com/recastnavigation/recastnavigation/commit/14b2631527c4792e95b2c78ebfa8ac4cd3413363

Ref https://github.com/recastnavigation/recastnavigation/issues/343