### PR TITLE
Add consistent input validation to dtNavMeshQuery

### DIFF
--- a/Detour/Include/DetourCommon.h
+++ b/Detour/Include/DetourCommon.h
@@ -283,6 +283,28 @@ inline bool dtVequal(const float* p0, const float* p1)
 	return d < thr;
 }
 
+/// Checks that the specified vector's components are all finite.
+///  @param[in]		v	A point. [(x, y, z)]
+/// @return True if all of the point's components are finite, i.e. not NaN
+/// or any of the infinities.
+inline bool dtVisfinite(const float* v)
+{
+	bool result =
+		dtMathIsfinite(v[0]) &&
+		dtMathIsfinite(v[1]) &&
+		dtMathIsfinite(v[2]);
+
+	return result;
+}
+
+/// Checks that the specified vector's 2D components are finite.
+///  @param[in]		v	A point. [(x, y, z)]
+inline bool dtVisfinite2D(const float* v)
+{
+	bool result = dtMathIsfinite(v[0]) && dtMathIsfinite(v[2]);
+	return result;
+}
+
 /// Derives the dot product of two vectors on the xz-plane. (@p u . @p v)
 ///  @param[in]		u		A vector [(x, y, z)]
 ///  @param[in]		v		A vector [(x, y, z)]

--- a/Detour/Include/DetourMath.h
+++ b/Detour/Include/DetourMath.h
@@ -16,5 +16,6 @@ inline float dtMathCeilf(float x) { return ceilf(x); }
 inline float dtMathCosf(float x) { return cosf(x); }
 inline float dtMathSinf(float x) { return sinf(x); }
 inline float dtMathAtan2f(float y, float x) { return atan2f(y, x); }
+inline bool dtMathIsfinite(float x) { return isfinite(x); }
 
 #endif

--- a/Detour/Include/DetourMath.h
+++ b/Detour/Include/DetourMath.h
@@ -8,6 +8,9 @@ Members in this module are wrappers around the standard math library
 #define DETOURMATH_H
 
 #include <math.h>
+// This include is required because libc++ has problems with isfinite
+// if cmath is included before math.h.
+#include <cmath>
 
 inline float dtMathFabsf(float x) { return fabsf(x); }
 inline float dtMathSqrtf(float x) { return sqrtf(x); }
@@ -16,6 +19,6 @@ inline float dtMathCeilf(float x) { return ceilf(x); }
 inline float dtMathCosf(float x) { return cosf(x); }
 inline float dtMathSinf(float x) { return sinf(x); }
 inline float dtMathAtan2f(float y, float x) { return atan2f(y, x); }
-inline bool dtMathIsfinite(float x) { return isfinite(x); }
+inline bool dtMathIsfinite(float x) { return std::isfinite(x); }
 
 #endif

--- a/Detour/Include/DetourMath.h
+++ b/Detour/Include/DetourMath.h
@@ -8,7 +8,7 @@ Members in this module are wrappers around the standard math library
 #define DETOURMATH_H
 
 #include <math.h>
-// This include is required because libc++ has problems with isfinite
+// This include is required because libstdc++ has problems with isfinite
 // if cmath is included before math.h.
 #include <cmath>
 

--- a/Detour/Source/DetourNavMeshQuery.cpp
+++ b/Detour/Source/DetourNavMeshQuery.cpp
@@ -1301,8 +1301,8 @@ dtStatus dtNavMeshQuery::initSlicedFindPath(dtPolyRef startRef, dtPolyRef endRef
 	m_query.raycastLimitSqr = FLT_MAX;
 	
 	// Validate input
-	if (!m_nav->isValidPolyRef(startRef) || !m_nav->isValidPolyRef(endRef)
-		|| !startPos || !dtVisfinite(startPos) ||
+	if (!m_nav->isValidPolyRef(startRef) || !m_nav->isValidPolyRef(endRef) ||
+		!startPos || !dtVisfinite(startPos) ||
 		!endPos || !dtVisfinite(endPos) || !filter)
 	{
 		return DT_FAILURE | DT_INVALID_PARAM;

--- a/Detour/Source/DetourNavMeshQuery.cpp
+++ b/Detour/Source/DetourNavMeshQuery.cpp
@@ -2781,10 +2781,8 @@ dtStatus dtNavMeshQuery::findPolysAroundCircle(dtPolyRef startRef, const float* 
 	{
 		return DT_FAILURE | DT_INVALID_PARAM;
 	}
-	
-	// Validate input
-	if (!startRef || !m_nav->isValidPolyRef(startRef))
-		return DT_FAILURE | DT_INVALID_PARAM;
+
+	*resultCount = 0;
 	
 	m_nodePool->clear();
 	m_openList->clear();


### PR DESCRIPTION
Validate input values more consistently and completely, including that points are finite.
This would have saved everyone some time in #343/#373.