### PR TITLE
Permit false positive compile errors (gcc8)

### DIFF
--- a/RecastDemo/premake5.lua
+++ b/RecastDemo/premake5.lua
@@ -73,6 +73,12 @@ project "Detour"
 		"../Detour/Include/*.h", 
 		"../Detour/Source/*.cpp" 
 	}
+	-- linux library cflags and libs
+	configuration { "linux", "gmake" }
+		buildoptions { 
+			"-Wno-error=class-memaccess"
+		}
+
 
 project "DetourCrowd"
 	language "C++"
@@ -148,7 +154,10 @@ project "RecastDemo"
 		buildoptions { 
 			"`pkg-config --cflags sdl2`",
 			"`pkg-config --cflags gl`",
-			"`pkg-config --cflags glu`" 
+			"`pkg-config --cflags glu`",
+			"-Wno-ignored-qualifiers",
+			"-Wno-error=class-memaccess"
+
 		}
 		linkoptions { 
 			"`pkg-config --libs sdl2`",


### PR DESCRIPTION
# Commit description
Using premake5 as described in the README it is currently not possible to compile the _RecastDemo_ under gcc8. Because warnings are treated as errors due to the "-Werror" compiler flag, false positive warnings cause the compilation to fail.

This commit adds appropriate no-error exception flags in the lua script and allows for a successful build under gcc8. Fixes #380.

It is possible to build the complete project using the main cmake file without these errors!

# Tested on
5.0.13-arch1-1-ARCH #1 SMP PREEMPT Sun May 5 18:05:41 UTC 2019 x86_64 GNU/Linux
gcc version 8.3.0

# Appendix: Affected files and produced warnings
## Detour:
`../../../Detour/Source/DetourNavMesh.cpp: In member function ‘dtStatus dtNavMesh::init(const dtNavMeshParams*)’:
../../../Detour/Source/DetourNavMesh.cpp:243:50: error: ‘void* memset(void*, int, size_t)’ clearing an object of type ‘struct dtMeshTile’ with no trivial copy-assignment [-Werror=class-memaccess]
  memset(m_tiles, 0, sizeof(dtMeshTile)*m_maxTiles);`
## RecastDemo:
1. `../../Source/Sample_TempObstacles.cpp: In member function ‘virtual dtStatus FastLZCompressor::compress(const unsigned char*, int, unsigned char*, int, int*)’:
../../Source/Sample_TempObstacles.cpp:120:56: error: type qualifiers ignored on cast result type [-Werror=ignored-qualifiers]
   *compressedSize = fastlz_compress((const void *const)buffer, bufferSize, compressed);`
2. `../../Source/Sample_TempObstacles.cpp: In member function ‘virtual dtStatus FastLZCompressor::compress(const unsigned char*, int, unsigned char*, int, int*)’:
../../Source/Sample_TempObstacles.cpp:120:56: error: type qualifiers ignored on cast result type [-Werror=ignored-qualifiers]
   *compressedSize = fastlz_compress((const void *const)buffer, bufferSize, compressed);`