### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ Recast is accompanied with Detour, path-finding and spatial reasoning toolkit. Y
 
 Detour offers simple static navigation mesh which is suitable for many simple cases, as well as tiled navigation mesh which allows you to plug in and out pieces of the mesh. The tiled mesh allows you to create systems where you stream new navigation data in and out as the player progresses the level, or you may regenerate tiles as the world changes. 
 
+## Installation through vcpkg
+
+If you are using the [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager you can download and install Recast with a single command:
+```
+vcpkg install recast
+```
 
 ## Recast Demo
 


### PR DESCRIPTION
Recast is available as a port in vcpkg. Adding installation instructions will help users get started by providing a single command they can use to build Recast and include it into their projects