### PR TITLE
Updates the README instructions for linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ RecastDemo uses [premake5](http://premake.github.io/) to build platform specific
 - Install SDL2 and its dependencies according to your distro's guidelines.
 - run `premake5 gmake` from the `RecastDemo` folder.
 - `cd Build/gmake` then `make`
-- Run `RecastDemo\Bin\RecastDemo`
+- `cd RecastDemo/Bin` and then run `./RecastDemo`
 
 #### OSX
 


### PR DESCRIPTION
The binary has to be run from the bin directory, otherwise the DroidSans font can't be found and shows the error "Could not init GUI renderer.":

https://github.com/recastnavigation/recastnavigation/blob/master/RecastDemo/Source/main.cpp#L129