### PR TITLE
Fix build

### DIFF
--- a/RecastDemo/premake5.lua
+++ b/RecastDemo/premake5.lua
@@ -76,7 +76,7 @@ project "Detour"
 	-- linux library cflags and libs
 	configuration { "linux", "gmake" }
 		buildoptions { 
-			"-Wno-error=class-memaccess"
+			"-Wno-class-memaccess"
 		}
 
 
@@ -156,7 +156,7 @@ project "RecastDemo"
 			"`pkg-config --cflags gl`",
 			"`pkg-config --cflags glu`",
 			"-Wno-ignored-qualifiers",
-			"-Wno-error=class-memaccess"
+			"-Wno-class-memaccess"
 
 		}
 		linkoptions { 


### PR DESCRIPTION
-Wno-error does not ignore unknown warnings on old GCC versions causing
problems when using it for new warnings. On the other hand, -Wno-X will
ignore unknown warnings, so we can use this instead.

Fix #403
Fix #413