### PR TITLE
Fix shared library build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,10 @@ SET(VERSION 1.0.0)
 option(RECASTNAVIGATION_DEMO "Build demo" ON)
 option(RECASTNAVIGATION_TESTS "Build tests" ON)
 option(RECASTNAVIGATION_EXAMPLES "Build examples" ON)
-option(RECASTNAVIGATION_STATIC "Build static libraries" ON)
+
+if(MSVC AND BUILD_SHARED_LIBS)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
 
 include(GNUInstallDirs)
 

--- a/DebugUtils/CMakeLists.txt
+++ b/DebugUtils/CMakeLists.txt
@@ -1,10 +1,5 @@
 file(GLOB SOURCES Source/*.cpp)
-
-if (RECASTNAVIGATION_STATIC)
-    add_library(DebugUtils STATIC ${SOURCES})
-else()
-    add_library(DebugUtils SHARED ${SOURCES})
-endif()
+add_library(DebugUtils ${SOURCES})
 
 add_library(RecastNavigation::DebugUtils ALIAS DebugUtils)
 set_target_properties(DebugUtils PROPERTIES DEBUG_POSTFIX -d)
@@ -29,6 +24,7 @@ set_target_properties(DebugUtils PROPERTIES
         )
 
 install(TARGETS DebugUtils
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         COMPONENT library

--- a/Detour/CMakeLists.txt
+++ b/Detour/CMakeLists.txt
@@ -1,10 +1,5 @@
 file(GLOB SOURCES Source/*.cpp)
-
-if(RECASTNAVIGATION_STATIC)
-    add_library(Detour STATIC ${SOURCES})
-else()
-    add_library(Detour SHARED ${SOURCES})
-endif()
+add_library(Detour ${SOURCES})
 
 add_library(RecastNavigation::Detour ALIAS Detour)
 set_target_properties(Detour PROPERTIES DEBUG_POSTFIX -d)
@@ -23,6 +18,7 @@ set_target_properties(Detour PROPERTIES
         )
 
 install(TARGETS Detour
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         COMPONENT library

--- a/DetourCrowd/CMakeLists.txt
+++ b/DetourCrowd/CMakeLists.txt
@@ -1,10 +1,5 @@
 file(GLOB SOURCES Source/*.cpp)
-
-if (RECASTNAVIGATION_STATIC)
-    add_library(DetourCrowd STATIC ${SOURCES})
-else ()
-    add_library(DetourCrowd SHARED ${SOURCES})
-endif ()
+add_library(DetourCrowd ${SOURCES})
 
 add_library(RecastNavigation::DetourCrowd ALIAS DetourCrowd)
 set_target_properties(DetourCrowd PROPERTIES DEBUG_POSTFIX -d)
@@ -27,6 +22,7 @@ set_target_properties(DetourCrowd PROPERTIES
         )
 
 install(TARGETS DetourCrowd
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         COMPONENT library

--- a/DetourTileCache/CMakeLists.txt
+++ b/DetourTileCache/CMakeLists.txt
@@ -1,10 +1,5 @@
 file(GLOB SOURCES Source/*.cpp)
-
-if (RECASTNAVIGATION_STATIC)
-    add_library(DetourTileCache STATIC ${SOURCES})
-else ()
-    add_library(DetourTileCache SHARED ${SOURCES})
-endif ()
+add_library(DetourTileCache ${SOURCES})
 
 add_library(RecastNavigation::DetourTileCache ALIAS DetourTileCache)
 set_target_properties(DetourTileCache PROPERTIES DEBUG_POSTFIX -d)
@@ -28,6 +23,7 @@ set_target_properties(DetourTileCache PROPERTIES
 
 
 install(TARGETS DetourTileCache
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         COMPONENT library

--- a/Recast/CMakeLists.txt
+++ b/Recast/CMakeLists.txt
@@ -1,10 +1,5 @@
 file(GLOB SOURCES Source/*.cpp)
-
-if (RECASTNAVIGATION_STATIC)
-    add_library(Recast STATIC ${SOURCES})
-else ()
-    add_library(Recast SHARED ${SOURCES})
-endif ()
+add_library(Recast ${SOURCES})
 
 add_library(RecastNavigation::Recast ALIAS Recast)
 set_target_properties(Recast PROPERTIES DEBUG_POSTFIX -d)
@@ -23,6 +18,7 @@ set_target_properties(Recast PROPERTIES
         )
 
 install(TARGETS Recast
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         COMPONENT library


### PR DESCRIPTION
- Export symbols with MSVC
- Delete `RECASTNAVIGATION_STATIC` option, [BUILD_SHARED_LIBS](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html) is better
- Install shared runtime library in `bin` folder
