### PR TITLE
Improve debug builds for MSVC

### DIFF
--- a/DebugUtils/CMakeLists.txt
+++ b/DebugUtils/CMakeLists.txt
@@ -7,6 +7,7 @@ else()
 endif()
 
 add_library(RecastNavigation::DebugUtils ALIAS DebugUtils)
+set_target_properties(DebugUtils PROPERTIES DEBUG_POSTFIX -d)
 
 set(DebugUtils_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Include")
 

--- a/DebugUtils/CMakeLists.txt
+++ b/DebugUtils/CMakeLists.txt
@@ -24,6 +24,8 @@ target_link_libraries(DebugUtils
 set_target_properties(DebugUtils PROPERTIES
         SOVERSION ${SOVERSION}
         VERSION ${VERSION}
+        COMPILE_PDB_OUTPUT_DIRECTORY .
+        COMPILE_PDB_NAME "DebugUtils-d"
         )
 
 install(TARGETS DebugUtils
@@ -35,3 +37,4 @@ install(TARGETS DebugUtils
 file(GLOB INCLUDES Include/*.h)
 install(FILES ${INCLUDES} DESTINATION
     ${CMAKE_INSTALL_INCLUDEDIR}/recastnavigation)
+install(FILES "$<TARGET_FILE_DIR:DebugUtils>/DebugUtils-d.pdb" CONFIGURATIONS "Debug" DESTINATION "lib") 

--- a/Detour/CMakeLists.txt
+++ b/Detour/CMakeLists.txt
@@ -7,6 +7,7 @@ else()
 endif()
 
 add_library(RecastNavigation::Detour ALIAS Detour)
+set_target_properties(Detour PROPERTIES DEBUG_POSTFIX -d)
 
 set(Detour_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Include")
 

--- a/Detour/CMakeLists.txt
+++ b/Detour/CMakeLists.txt
@@ -18,6 +18,8 @@ target_include_directories(Detour PUBLIC
 set_target_properties(Detour PROPERTIES
         SOVERSION ${SOVERSION}
         VERSION ${VERSION}
+        COMPILE_PDB_OUTPUT_DIRECTORY .
+        COMPILE_PDB_NAME "Detour-d"
         )
 
 install(TARGETS Detour
@@ -29,3 +31,4 @@ install(TARGETS Detour
 file(GLOB INCLUDES Include/*.h)
 install(FILES ${INCLUDES} DESTINATION
     ${CMAKE_INSTALL_INCLUDEDIR}/recastnavigation)
+install(FILES "$<TARGET_FILE_DIR:Detour>/Detour-d.pdb" CONFIGURATIONS "Debug" DESTINATION "lib") 

--- a/DetourCrowd/CMakeLists.txt
+++ b/DetourCrowd/CMakeLists.txt
@@ -22,6 +22,8 @@ target_link_libraries(DetourCrowd
 set_target_properties(DetourCrowd PROPERTIES
         SOVERSION ${SOVERSION}
         VERSION ${VERSION}
+        COMPILE_PDB_OUTPUT_DIRECTORY .
+        COMPILE_PDB_NAME "DetourCrowd-d"
         )
 
 install(TARGETS DetourCrowd
@@ -33,3 +35,4 @@ install(TARGETS DetourCrowd
 file(GLOB INCLUDES Include/*.h)
 install(FILES ${INCLUDES} DESTINATION
     ${CMAKE_INSTALL_INCLUDEDIR}/recastnavigation)
+install(FILES "$<TARGET_FILE_DIR:DetourCrowd>/DetourCrowd-d.pdb" CONFIGURATIONS "Debug" DESTINATION "lib") 

--- a/DetourCrowd/CMakeLists.txt
+++ b/DetourCrowd/CMakeLists.txt
@@ -7,6 +7,7 @@ else ()
 endif ()
 
 add_library(RecastNavigation::DetourCrowd ALIAS DetourCrowd)
+set_target_properties(DetourCrowd PROPERTIES DEBUG_POSTFIX -d)
 
 set(DetourCrowd_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Include")
 

--- a/DetourTileCache/CMakeLists.txt
+++ b/DetourTileCache/CMakeLists.txt
@@ -7,6 +7,7 @@ else ()
 endif ()
 
 add_library(RecastNavigation::DetourTileCache ALIAS DetourTileCache)
+set_target_properties(DetourTileCache PROPERTIES DEBUG_POSTFIX -d)
 
 set(DetourTileCache_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Include")
 

--- a/DetourTileCache/CMakeLists.txt
+++ b/DetourTileCache/CMakeLists.txt
@@ -22,6 +22,8 @@ target_link_libraries(DetourTileCache
 set_target_properties(DetourTileCache PROPERTIES
         SOVERSION ${SOVERSION}
         VERSION ${VERSION}
+        COMPILE_PDB_OUTPUT_DIRECTORY .
+        COMPILE_PDB_NAME "DetourTileCache-d"
         )
 
 
@@ -34,3 +36,4 @@ install(TARGETS DetourTileCache
 file(GLOB INCLUDES Include/*.h)
 install(FILES ${INCLUDES} DESTINATION
     ${CMAKE_INSTALL_INCLUDEDIR}/recastnavigation)
+install(FILES "$<TARGET_FILE_DIR:DetourTileCache>/DetourTileCache-d.pdb" CONFIGURATIONS "Debug" DESTINATION "lib") 

--- a/Recast/CMakeLists.txt
+++ b/Recast/CMakeLists.txt
@@ -7,6 +7,7 @@ else ()
 endif ()
 
 add_library(RecastNavigation::Recast ALIAS Recast)
+set_target_properties(Recast PROPERTIES DEBUG_POSTFIX -d)
 
 set(Recast_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Include")
 

--- a/Recast/CMakeLists.txt
+++ b/Recast/CMakeLists.txt
@@ -18,6 +18,8 @@ target_include_directories(Recast PUBLIC
 set_target_properties(Recast PROPERTIES
         SOVERSION ${SOVERSION}
         VERSION ${VERSION}
+        COMPILE_PDB_OUTPUT_DIRECTORY .
+        COMPILE_PDB_NAME "Recast-d"
         )
 
 install(TARGETS Recast
@@ -29,3 +31,4 @@ install(TARGETS Recast
 file(GLOB INCLUDES Include/*.h)
 install(FILES ${INCLUDES} DESTINATION
     ${CMAKE_INSTALL_INCLUDEDIR}/recastnavigation)
+install(FILES "$<TARGET_FILE_DIR:Recast>/Recast-d.pdb" CONFIGURATIONS "Debug" DESTINATION "lib") 


### PR DESCRIPTION
Two changes that make life easier when using the _Visual Studio_ and _nmake_ generators in CMake:

1. When compiling both Release/Debug (e.g. as a batch build inside Visual Studio), it no longer overwrites libraries .lib files. Instead, it creates distinct ones for Release (the same as before), while it adds the `-d` postfix for Debug configuration.

2. Exports PDB files alongside the libraries in Debug mode. This makes it possible that dependent projects have Debug symbols for Recast/Detour available, and avoids linker warnings for missing debug symbols.

Both changes should have no effects when the Microsoft compiler is not used.