### PR TITLE
Poly query API: expose distance and isOverPoly

### DIFF
--- a/Detour/Include/DetourNavMeshQuery.h
+++ b/Detour/Include/DetourNavMeshQuery.h
@@ -313,24 +313,28 @@ public:
 	///@{
 
 	/// Finds the polygon nearest to the specified center point.
+	/// [opt] means the specified parameter can be a null pointer, in that case the output parameter will not be set.
+	///
 	///  @param[in]		center		The center of the search box. [(x, y, z)]
-	///  @param[in]		halfExtents		The search distance along each axis. [(x, y, z)]
+	///  @param[in]		halfExtents	The search distance along each axis. [(x, y, z)]
 	///  @param[in]		filter		The polygon filter to apply to the query.
-	///  @param[out]	nearestRef	The reference id of the nearest polygon.
-	///  @param[out]	nearestPt	The nearest point on the polygon. [opt] [(x, y, z)]
+	///  @param[out]	nearestRef	The reference id of the nearest polygon. Will be set to 0 if no polygon is found.
+	///  @param[out]	nearestPt	The nearest point on the polygon. Unchanged if no polygon is found. [opt] [(x, y, z)]
 	/// @returns The status flags for the query.
 	dtStatus findNearestPoly(const float* center, const float* halfExtents,
 							 const dtQueryFilter* filter,
 							 dtPolyRef* nearestRef, float* nearestPt) const;
 
 	/// Finds the polygon nearest to the specified center point.
+	/// [opt] means the specified parameter can be a null pointer, in that case the output parameter will not be set.
+	/// 
 	///  @param[in]		center		The center of the search box. [(x, y, z)]
-	///  @param[in]		halfExtents		The search distance along each axis. [(x, y, z)]
+	///  @param[in]		halfExtents	The search distance along each axis. [(x, y, z)]
 	///  @param[in]		filter		The polygon filter to apply to the query.
-	///  @param[out]	nearestRef	The reference id of the nearest polygon.
-	///  @param[out]	nearestPt	The nearest point on the polygon. [opt] [(x, y, z)]
-	///  @param[out]	isOverPoly 	True if the point lies inside the polygon, false otherwise.
-	///  @param[out]	distance 	If not nullptr: Distance from point to the polygon. If center is inside the polygon, this is the abs Y distance only (so not necessarily 0).
+	///  @param[out]	nearestRef	The reference id of the nearest polygon. Will be set to 0 if no polygon is found.
+	///  @param[out]	nearestPt	The nearest point on the polygon. Unchanged if no polygon is found. [opt] [(x, y, z)]
+	///  @param[out]	isOverPoly 	Set to true if the point lies inside the polygon, false otherwise. Unchanged if no polygon is found. [opt]
+	///  @param[out]	distance 	Distance from point to the polygon. If center is inside the polygon, this is the abs Y distance only (so not necessarily 0). Unchanged if no polygon is found. [opt]
 	/// @returns The status flags for the query.
 	dtStatus findNearestPoly(const float* center, const float* halfExtents,
 							 const dtQueryFilter* filter,

--- a/Detour/Include/DetourNavMeshQuery.h
+++ b/Detour/Include/DetourNavMeshQuery.h
@@ -322,6 +322,19 @@ public:
 	dtStatus findNearestPoly(const float* center, const float* halfExtents,
 							 const dtQueryFilter* filter,
 							 dtPolyRef* nearestRef, float* nearestPt) const;
+
+	/// Finds the polygon nearest to the specified center point.
+	///  @param[in]		center		The center of the search box. [(x, y, z)]
+	///  @param[in]		halfExtents		The search distance along each axis. [(x, y, z)]
+	///  @param[in]		filter		The polygon filter to apply to the query.
+	///  @param[out]	nearestRef	The reference id of the nearest polygon.
+	///  @param[out]	nearestPt	The nearest point on the polygon. [opt] [(x, y, z)]
+	///  @param[out]	isOverPoly 	True if the point lies inside the polygon, false otherwise.
+	///  @param[out]	distance 	If not nullptr: Distance from point to the polygon. If center is inside the polygon, this is the abs Y distance only (so not necessarily 0).
+	/// @returns The status flags for the query.
+	dtStatus findNearestPoly(const float* center, const float* halfExtents,
+							 const dtQueryFilter* filter,
+							 dtPolyRef* nearestRef, float* nearestPt, bool* isOverPoly, float* distance) const;
 	
 	/// Finds polygons that overlap the search box.
 	///  @param[in]		center		The center of the search box. [(x, y, z)]

--- a/Detour/Include/DetourNavMeshQuery.h
+++ b/Detour/Include/DetourNavMeshQuery.h
@@ -333,12 +333,11 @@ public:
 	///  @param[in]		filter		The polygon filter to apply to the query.
 	///  @param[out]	nearestRef	The reference id of the nearest polygon. Will be set to 0 if no polygon is found.
 	///  @param[out]	nearestPt	The nearest point on the polygon. Unchanged if no polygon is found. [opt] [(x, y, z)]
-	///  @param[out]	isOverPoly 	Set to true if the point lies inside the polygon, false otherwise. Unchanged if no polygon is found. [opt]
-	///  @param[out]	distance 	Distance from point to the polygon. If center is inside the polygon, this is the abs Y distance only (so not necessarily 0). Unchanged if no polygon is found. [opt]
+	///  @param[out]	isOverPoly 	Set to true if the point's X/Z coordinate lies inside the polygon, false otherwise. Unchanged if no polygon is found. [opt]
 	/// @returns The status flags for the query.
 	dtStatus findNearestPoly(const float* center, const float* halfExtents,
 							 const dtQueryFilter* filter,
-							 dtPolyRef* nearestRef, float* nearestPt, bool* isOverPoly, float* distance) const;
+							 dtPolyRef* nearestRef, float* nearestPt, bool* isOverPoly) const;
 	
 	/// Finds polygons that overlap the search box.
 	///  @param[in]		center		The center of the search box. [(x, y, z)]

--- a/Detour/Source/DetourNavMeshQuery.cpp
+++ b/Detour/Source/DetourNavMeshQuery.cpp
@@ -641,7 +641,6 @@ public:
 	dtPolyRef nearestRef() const { return m_nearestRef; }
 	const float* nearestPoint() const { return m_nearestPoint; }
 	bool isOverPoly() const { return m_overPoly; }
-	float distance() const { return sqrt(m_nearestDistanceSqr); } // only called when explicitly requested
 
 	void process(const dtMeshTile* tile, dtPoly** polys, dtPolyRef* refs, int count)
 	{
@@ -691,14 +690,14 @@ dtStatus dtNavMeshQuery::findNearestPoly(const float* center, const float* halfE
 										 const dtQueryFilter* filter,
 										 dtPolyRef* nearestRef, float* nearestPt) const
 {
-	return findNearestPoly(center, halfExtents, filter, nearestRef, nearestPt, NULL, NULL);
+	return findNearestPoly(center, halfExtents, filter, nearestRef, nearestPt, NULL);
 }
 
 // If center and nearestPt point to an equal position, isOverPoly will be true;
 // however there's also a special case of climb height inside the polygon (see dtFindNearestPolyQuery)
 dtStatus dtNavMeshQuery::findNearestPoly(const float* center, const float* halfExtents,
 										 const dtQueryFilter* filter,
-										 dtPolyRef* nearestRef, float* nearestPt, bool* isOverPoly, float* distance) const
+										 dtPolyRef* nearestRef, float* nearestPt, bool* isOverPoly) const
 {
 	dtAssert(m_nav);
 
@@ -721,8 +720,6 @@ dtStatus dtNavMeshQuery::findNearestPoly(const float* center, const float* halfE
 		dtVcopy(nearestPt, query.nearestPoint());
 		if (isOverPoly)
 			*isOverPoly = query.isOverPoly();
-		if (distance)
-			*distance = query.distance();
 	}
 	
 	return DT_SUCCESS;

--- a/Detour/Source/DetourNavMeshQuery.cpp
+++ b/Detour/Source/DetourNavMeshQuery.cpp
@@ -691,26 +691,7 @@ dtStatus dtNavMeshQuery::findNearestPoly(const float* center, const float* halfE
 										 const dtQueryFilter* filter,
 										 dtPolyRef* nearestRef, float* nearestPt) const
 {
-	dtAssert(m_nav);
-
-	if (!nearestRef)
-		return DT_FAILURE | DT_INVALID_PARAM;
-
-	// queryPolygons below will check rest of params
-	
-	dtFindNearestPolyQuery query(this, center);
-
-	dtStatus status = queryPolygons(center, halfExtents, filter, &query);
-	if (dtStatusFailed(status))
-		return status;
-
-	*nearestRef = query.nearestRef();
-	// Only override nearestPt if we actually found a poly so the nearest point
-	// is valid.
-	if (nearestPt && *nearestRef)
-		dtVcopy(nearestPt, query.nearestPoint());
-	
-	return DT_SUCCESS;
+	return findNearestPoly(center, halfExtents, filter, nearestRef, nearestPt, nullptr, nullptr);
 }
 
 // If center and nearestPt point to an equal position, isOverPoly will be true;
@@ -738,7 +719,8 @@ dtStatus dtNavMeshQuery::findNearestPoly(const float* center, const float* halfE
 	if (nearestPt && *nearestRef)
 	{
 		dtVcopy(nearestPt, query.nearestPoint());
-		*isOverPoly = query.isOverPoly();
+		if (isOverPoly)
+			*isOverPoly = query.isOverPoly();
 		if (distance)
 			*distance = query.distance();
 	}

--- a/Detour/Source/DetourNavMeshQuery.cpp
+++ b/Detour/Source/DetourNavMeshQuery.cpp
@@ -691,7 +691,7 @@ dtStatus dtNavMeshQuery::findNearestPoly(const float* center, const float* halfE
 										 const dtQueryFilter* filter,
 										 dtPolyRef* nearestRef, float* nearestPt) const
 {
-	return findNearestPoly(center, halfExtents, filter, nearestRef, nearestPt, nullptr, nullptr);
+	return findNearestPoly(center, halfExtents, filter, nearestRef, nearestPt, NULL, NULL);
 }
 
 // If center and nearestPt point to an equal position, isOverPoly will be true;


### PR DESCRIPTION
The current API `dtNavMeshQuery::findNearerestPoly()` does not allow the caller to get information about:
* whether `center` is actually _on_ a polygon
* what is the distance to the polygon (even if it's _on_ one, this can be vertical distance).

Of course it would be possible for the caller to compute these after the call, however `findNearestPoly()` has the information readily available.

I simply added an overload and didn't de-duplicate code, please let me know if you think such an API makes sense, and what would be the preferred way.