### PR TITLE
Validate constraint: #polygons per tile

### DIFF
--- a/Detour/Include/DetourNavMesh.h
+++ b/Detour/Include/DetourNavMesh.h
@@ -330,7 +330,7 @@ struct dtNavMeshParams
 	float tileWidth;				///< The width of each tile. (Along the x-axis.)
 	float tileHeight;				///< The height of each tile. (Along the z-axis.)
 	int maxTiles;					///< The maximum number of tiles the navigation mesh can contain.
-	int maxPolys;					///< The maximum number of polygons each tile can contain.
+	int maxPolys;					///< The maximum number of polygons each tile can contain. Does not influence the build step, however adding a tile with more polygons will fail.
 };
 
 /// A navigation mesh based on tiles of convex polygons.

--- a/Detour/Include/DetourNavMesh.h
+++ b/Detour/Include/DetourNavMesh.h
@@ -329,8 +329,8 @@ struct dtNavMeshParams
 	float orig[3];					///< The world space origin of the navigation mesh's tile space. [(x, y, z)]
 	float tileWidth;				///< The width of each tile. (Along the x-axis.)
 	float tileHeight;				///< The height of each tile. (Along the z-axis.)
-	int maxTiles;					///< The maximum number of tiles the navigation mesh can contain.
-	int maxPolys;					///< The maximum number of polygons each tile can contain. Does not influence the build step, however adding a tile with more polygons will fail.
+	int maxTiles;					///< The maximum number of tiles the navigation mesh can contain. This and maxPolys are used to calculate how many bits are needed to identify tiles and polygons uniquely.
+	int maxPolys;					///< The maximum number of polygons each tile can contain. This and maxTiles are used to calculate how many bits are needed to identify tiles and polygons uniquely.
 };
 
 /// A navigation mesh based on tiles of convex polygons.

--- a/Detour/Source/DetourNavMesh.cpp
+++ b/Detour/Source/DetourNavMesh.cpp
@@ -914,6 +914,13 @@ dtStatus dtNavMesh::addTile(unsigned char* data, int dataSize, int flags,
 		return DT_FAILURE | DT_WRONG_MAGIC;
 	if (header->version != DT_NAVMESH_VERSION)
 		return DT_FAILURE | DT_WRONG_VERSION;
+
+#ifndef DT_POLYREF64
+	// Do not allow adding more polygons than specified in the NavMesh's maxPolys constraint.
+	// Otherwise, the poly ID cannot be represented with the given number of bits.
+	if (m_polyBits < dtIlog2(dtNextPow2((unsigned int)header->polyCount)))
+		return DT_FAILURE | DT_INVALID_PARAM;
+#endif
 		
 	// Make sure the location is free.
 	if (getTileAt(header->x, header->y, header->layer))


### PR DESCRIPTION
When adding a tile to a NavMesh, ensure that the number of polygons in that tile fit in the poly ID address space.

I'm not sure if this should be done on the bits (logarithmic) level only, or if it were better if the absolute number of polygons (i.e. `dtNavMeshParams::maxPolys`) should be stored in `DetourNavMesh` and validated. However, this may be a bit harder, since we would need to sum the polygon count for each tile.

Generally, it's not very clear from the documentation how `maxPolys` is used.