### PR TITLE
Install .pdb files only on windows

### DIFF
--- a/DebugUtils/CMakeLists.txt
+++ b/DebugUtils/CMakeLists.txt
@@ -33,4 +33,6 @@ install(TARGETS DebugUtils
 file(GLOB INCLUDES Include/*.h)
 install(FILES ${INCLUDES} DESTINATION
     ${CMAKE_INSTALL_INCLUDEDIR}/recastnavigation)
-install(FILES "$<TARGET_FILE_DIR:DebugUtils>/DebugUtils-d.pdb" CONFIGURATIONS "Debug" DESTINATION "lib") 
+if(MSVC)
+    install(FILES "$<TARGET_FILE_DIR:DebugUtils>/DebugUtils-d.pdb" CONFIGURATIONS "Debug" DESTINATION "lib")
+endif()

--- a/Detour/CMakeLists.txt
+++ b/Detour/CMakeLists.txt
@@ -27,4 +27,6 @@ install(TARGETS Detour
 file(GLOB INCLUDES Include/*.h)
 install(FILES ${INCLUDES} DESTINATION
     ${CMAKE_INSTALL_INCLUDEDIR}/recastnavigation)
-install(FILES "$<TARGET_FILE_DIR:Detour>/Detour-d.pdb" CONFIGURATIONS "Debug" DESTINATION "lib") 
+if(MSVC)
+    install(FILES "$<TARGET_FILE_DIR:Detour>/Detour-d.pdb" CONFIGURATIONS "Debug" DESTINATION "lib")
+endif()

--- a/DetourCrowd/CMakeLists.txt
+++ b/DetourCrowd/CMakeLists.txt
@@ -31,4 +31,6 @@ install(TARGETS DetourCrowd
 file(GLOB INCLUDES Include/*.h)
 install(FILES ${INCLUDES} DESTINATION
     ${CMAKE_INSTALL_INCLUDEDIR}/recastnavigation)
-install(FILES "$<TARGET_FILE_DIR:DetourCrowd>/DetourCrowd-d.pdb" CONFIGURATIONS "Debug" DESTINATION "lib") 
+if(MSVC)
+    install(FILES "$<TARGET_FILE_DIR:DetourCrowd>/DetourCrowd-d.pdb" CONFIGURATIONS "Debug" DESTINATION "lib")
+endif()

--- a/DetourTileCache/CMakeLists.txt
+++ b/DetourTileCache/CMakeLists.txt
@@ -32,4 +32,6 @@ install(TARGETS DetourTileCache
 file(GLOB INCLUDES Include/*.h)
 install(FILES ${INCLUDES} DESTINATION
     ${CMAKE_INSTALL_INCLUDEDIR}/recastnavigation)
-install(FILES "$<TARGET_FILE_DIR:DetourTileCache>/DetourTileCache-d.pdb" CONFIGURATIONS "Debug" DESTINATION "lib") 
+if(MSVC)
+    install(FILES "$<TARGET_FILE_DIR:DetourTileCache>/DetourTileCache-d.pdb" CONFIGURATIONS "Debug" DESTINATION "lib")
+endif()

--- a/Recast/CMakeLists.txt
+++ b/Recast/CMakeLists.txt
@@ -27,4 +27,6 @@ install(TARGETS Recast
 file(GLOB INCLUDES Include/*.h)
 install(FILES ${INCLUDES} DESTINATION
     ${CMAKE_INSTALL_INCLUDEDIR}/recastnavigation)
-install(FILES "$<TARGET_FILE_DIR:Recast>/Recast-d.pdb" CONFIGURATIONS "Debug" DESTINATION "lib") 
+if(MSVC)
+    install(FILES "$<TARGET_FILE_DIR:Recast>/Recast-d.pdb" CONFIGURATIONS "Debug" DESTINATION "lib")
+endif()


### PR DESCRIPTION
These files are not generated on Linux that leads to an error:
```
CMake Error at DebugUtils/cmake_install.cmake:60 (file):
  file INSTALL cannot find
  "/home/elsid/dev/recastnavigation/build/gcc/debug/DebugUtils/DebugUtils-d.pdb":
  No such file or directory.
Call Stack (most recent call first):
  cmake_install.cmake:47 (include)
```