### PR TITLE
Added a filter for *.c files

### DIFF
--- a/RecastDemo/premake5.lua
+++ b/RecastDemo/premake5.lua
@@ -151,6 +151,7 @@ project "RecastDemo"
 
 	-- linux library cflags and libs
 	configuration { "linux", "gmake" }
+		filter { "files:*.c" }
 		buildoptions { 
 			"`pkg-config --cflags sdl2`",
 			"`pkg-config --cflags gl`",
@@ -159,6 +160,7 @@ project "RecastDemo"
 			"-Wno-class-memaccess"
 
 		}
+		filter {}
 		linkoptions { 
 			"`pkg-config --libs sdl2`",
 			"`pkg-config --libs gl`",


### PR DESCRIPTION
In Arch Linux, while I am building RecastDemo

Creating obj/Debug/RecastDemo
fastlz.c
ChunkyTriMesh.cpp
ConvexVolumeTool.cpp
CrowdTool.cpp
Filelist.cpp
cc1: error: command-line option '-Wno-class-memaccess' is valid for C++/ObjC++ but not for C [-Werror]

I looked up existing issues and pull requests, couldn't find this.

I added a filter to get around this. If this is reproducible on other platforms and acceptable, please include this.