### PR TITLE
Allow to declare variables of type dtMeshTile

### DIFF
--- a/Detour/Include/DetourNavMesh.h
+++ b/Detour/Include/DetourNavMesh.h
@@ -306,9 +306,6 @@ struct dtMeshTile
 	int dataSize;							///< Size of the tile data.
 	int flags;								///< Tile flags. (See: #dtTileFlags)
 	dtMeshTile* next;						///< The next free tile, or the next tile in the spatial grid.
-private:
-	dtMeshTile(const dtMeshTile&);
-	dtMeshTile& operator=(const dtMeshTile&);
 };
 
 /// Get flags for edge in detail triangle.


### PR DESCRIPTION
In general this change allows to write code like:
```c++
dtMeshTile tile;
```
With the only private copy constructor it's not possible.

Also it's completely ok to copy and copy-assign object of this type because there is no custom destructor. For example if I need to write custom function to map `unsigned char*` into `dtMeshTile` like it's done [here](https://github.com/recastnavigation/recastnavigation/blob/c5cbd53024c8a9d8d097a4371215e3342d2fdc87/Detour/Source/DetourNavMesh.cpp#L978-L996) I want to write a function:
```c++
dtMeshTile asMeshTile(unsigned char* data);
```
And this is fine because `dtMeshTile` is only a view to `data`.

All this is required to check equivalence of two navmesh tiles when one tile is [dtNavMesh::getTileAt](https://github.com/recastnavigation/recastnavigation/blob/c5cbd53024c8a9d8d097a4371215e3342d2fdc87/Detour/Include/DetourNavMesh.h#L395) result and the other is [dtCreateNavMeshData](https://github.com/recastnavigation/recastnavigation/blob/c5cbd53024c8a9d8d097a4371215e3342d2fdc87/Detour/Include/DetourNavMeshBuilder.h#L113) output.