### PR TITLE
Adds .os to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.pdb
 *.so
 *.idb
+*.os
 
 ## Linux exes have no extension
 RecastDemo/Bin/RecastDemo


### PR DESCRIPTION
Compiling in some contexts (in my case: Ubuntu, and godotdetour) will output .os files. Could be that someone typo'd .so somewhere. https://github.com/TheSHEEEP/godotdetour