### PR TITLE
Fixed RecastDemo crash in macOS 10.11+

### DIFF
--- a/Recast/Include/RecastAlloc.h
+++ b/Recast/Include/RecastAlloc.h
@@ -22,7 +22,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <RecastAssert.h>
+#include "RecastAssert.h"
 
 /// Provides hint values to the memory allocator on how long the
 /// memory is expected to be used.

--- a/RecastDemo/Source/main.cpp
+++ b/RecastDemo/Source/main.cpp
@@ -78,6 +78,9 @@ int main(int /*argc*/, char** /*argv*/)
 		return -1;
 	}
 
+    // Use OpenGL render driver.
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengl");
+
 	// Enable depth buffer.
 	SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
 	SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);


### PR DESCRIPTION
- Set SDL hints to always use OpenGL render driver (instead of Metal render driver by default)
- Compile error fix in Xcode 13 (replaced <RecastAssert.h> to "RecastAssert.h")