### PR TITLE
Abort rasterizeTri early to avoid segfault

### DIFF
--- a/Recast/Source/RecastRasterization.cpp
+++ b/Recast/Source/RecastRasterization.cpp
@@ -244,6 +244,9 @@ static bool rasterizeTri(const float* v0, const float* v1, const float* v2,
 						 const float cs, const float ics, const float ich,
 						 const int flagMergeThr)
 {
+	if ((hf.width == 0) || (hf.height == 0)) {
+		return true;
+	}
 	const int w = hf.width;
 	const int h = hf.height;
 	float tmin[3], tmax[3];


### PR DESCRIPTION
This PR fixes a bug when h=0 in lines 270-271:

```c++
y0 = rcClamp(y0, 0, h-1);
y1 = rcClamp(y1, 0, h-1);
```