### PR TITLE
Fix crash on load

### DIFF
--- a/RecastDemo/Source/Sample_SoloMesh.cpp
+++ b/RecastDemo/Source/Sample_SoloMesh.cpp
@@ -102,6 +102,8 @@ void Sample_SoloMesh::handleSettings()
 		dtFreeNavMesh(m_navMesh);
 		m_navMesh = Sample::loadAll("solo_navmesh.bin");
 		m_navQuery->init(m_navMesh, 2048);
+		if (m_tool)
+			m_tool->init(this);
 	}
 
 	imguiUnindent();

--- a/RecastDemo/Source/Sample_TempObstacles.cpp
+++ b/RecastDemo/Source/Sample_TempObstacles.cpp
@@ -930,6 +930,8 @@ void Sample_TempObstacles::handleSettings()
 		dtFreeTileCache(m_tileCache);
 		loadAll("all_tiles_tilecache.bin");
 		m_navQuery->init(m_navMesh, 2048);
+		if (m_tool)
+			m_tool->init(this);
 	}
 
 	imguiUnindent();

--- a/RecastDemo/Source/Sample_TileMesh.cpp
+++ b/RecastDemo/Source/Sample_TileMesh.cpp
@@ -283,6 +283,8 @@ void Sample_TileMesh::handleSettings()
 		dtFreeNavMesh(m_navMesh);
 		m_navMesh = Sample::loadAll("all_tiles_navmesh.bin");
 		m_navQuery->init(m_navMesh, 2048);
+		if (m_tool)
+			m_tool->init(this);
 	}
 
 	imguiUnindent();


### PR DESCRIPTION
Reproduce the crash:
1. Choose Sample -> Solo Mesh
2. Choose Mesh -> nav_test.obj
3. Build
4. Save
5. Load
6. Click on the map

Call stack:
```
>	RecastDemo.exe!dtNavMesh::getTileAndPolyByRef(const unsigned int ref, const dtMeshTile * * tile, const dtPoly * * poly) 行 1203	C++
 	RecastDemo.exe!duDebugDrawNavMeshPoly(duDebugDraw * dd, const dtNavMesh & mesh, unsigned int ref, const unsigned int col) 行 445	C++
 	RecastDemo.exe!NavMeshTesterTool::handleRender() 行 1070	C++
 	RecastDemo.exe!Sample_SoloMesh::handleRender() 行 342	C++
 	RecastDemo.exe!SDL_main(int __formal, char * * __formal) 行 493	C++
 	RecastDemo.exe!main_getcmdline() 行 82	C
 	[外部代码]
```