### PR TITLE
Fix -Wextra-semi GCC warnings by removing redundant semicolons

### DIFF
--- a/Recast/Include/RecastAlloc.h
+++ b/Recast/Include/RecastAlloc.h
@@ -112,7 +112,7 @@ class rcVectorBase {
 	typedef rcSizeType size_type;
 	typedef T value_type;
 
-	rcVectorBase() : m_size(0), m_cap(0), m_data(0) {};
+	rcVectorBase() : m_size(0), m_cap(0), m_data(0) {}
 	rcVectorBase(const rcVectorBase<T, H>& other) : m_size(0), m_cap(0), m_data(0) { assign(other.begin(), other.end()); }
 	explicit rcVectorBase(rcSizeType count) : m_size(0), m_cap(0), m_data(0) { resize(count); }
 	rcVectorBase(rcSizeType count, const T& value) : m_size(0), m_cap(0), m_data(0) { resize(count, value); }
@@ -142,8 +142,8 @@ class rcVectorBase {
 
 	const T& front() const { rcAssert(m_size); return m_data[0]; }
 	T& front() { rcAssert(m_size); return m_data[0]; }
-	const T& back() const { rcAssert(m_size); return m_data[m_size - 1]; };
-	T& back() { rcAssert(m_size); return m_data[m_size - 1]; };
+	const T& back() const { rcAssert(m_size); return m_data[m_size - 1]; }
+	T& back() { rcAssert(m_size); return m_data[m_size - 1]; }
 	const T* data() const { return m_data; }
 	T* data() { return m_data; }
 


### PR DESCRIPTION
Fixes these warnings triggered every time when `RecastAlloc.h` include is used (encountered in OpenMW):

```
/recastnavigation/Recast/Include/RecastAlloc.h:115:59: warning: extra «;» after in-class function definition [-Wextra-semi]
  115 |         rcVectorBase() : m_size(0), m_cap(0), m_data(0) {};
      |                                                           ^
      |                                                           -
/recastnavigation/Recast/Include/RecastAlloc.h:145:79: warning: extra «;» after in-class function definition [-Wextra-semi]
  145 |         const T& back() const { rcAssert(m_size); return m_data[m_size - 1]; };
      |                                                                               ^
      |                                                                               -
/recastnavigation/Recast/Include/RecastAlloc.h:146:67: warning: extra «;» after in-class function definition [-Wextra-semi]
  146 |         T& back() { rcAssert(m_size); return m_data[m_size - 1]; };
      |                                                                   ^
```

New formatting is consistent with the rest of file.