### PR TITLE
Don't explicitly create a GL context since SDL_CreateWindowAndRenderer does it internally.

### DIFF
--- a/RecastDemo/Source/main.cpp
+++ b/RecastDemo/Source/main.cpp
@@ -127,7 +127,6 @@ int main(int /*argc*/, char** /*argv*/)
 	}
 
 	SDL_SetWindowPosition(window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
-	SDL_GL_CreateContext(window);
 
 	if (!imguiRenderGLInit("DroidSans.ttf"))
 	{


### PR DESCRIPTION
Having two GL contexts causes rendering problems on Ubuntu.  

Fixes #521