### PR TITLE
Ignore generated dSYM debug symbols archive on mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ RecastDemo/Bin/Tests
 # Build directory
 RecastDemo/Build
 
+# XCode debug symbols archive
+RecastDemo/Bin/*.dSYM
+
 # Ignore meshes
 RecastDemo/Bin/Meshes/*
 


### PR DESCRIPTION
Xcode generates debug symbols in a folder under `Bin/` which isn't being properly ignored.