### PR TITLE
Disable class-memaccess error to fix builds on Ubuntu with newer versions of GCC

### DIFF
--- a/RecastDemo/premake5.lua
+++ b/RecastDemo/premake5.lua
@@ -76,7 +76,7 @@ project "Detour"
 	-- linux library cflags and libs
 	filter {"system:linux", "action:gmake"}
 		buildoptions {
-			"-Wno-class-memaccess"
+			"-Wno-error=class-memaccess"
 		}
 
 project "DetourCrowd"
@@ -155,7 +155,7 @@ project "RecastDemo"
 			"`pkg-config --cflags gl`",
 			"`pkg-config --cflags glu`",
 			"-Wno-ignored-qualifiers",
-			"-Wno-class-memaccess"
+			"-Wno-error=class-memaccess"
 
 		}
 		linkoptions { 


### PR DESCRIPTION
Based on SgtVincent's suggestion here: https://github.com/recastnavigation/recastnavigation/issues/497#issuecomment-1293318731

Demotes the warning from an error (due to warnings-as-errors) back to a warning.

Fixes #497