### PR TITLE
Install CMake config file to allow find_package()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ if(MSVC AND BUILD_SHARED_LIBS)
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 endif()
 
+include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 
 configure_file(
@@ -42,6 +43,38 @@ add_subdirectory(Detour)
 add_subdirectory(DetourCrowd)
 add_subdirectory(DetourTileCache)
 add_subdirectory(Recast)
+
+configure_package_config_file(
+    ${PROJECT_SOURCE_DIR}/recastnavigation-config.cmake.in
+    recastnavigation-config.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/recastnavigation
+)
+
+write_basic_package_version_file(
+    recastnavigation-config-version.cmake
+    VERSION ${LIB_VERSION}
+    COMPATIBILITY AnyNewerVersion
+)
+
+export(
+    EXPORT recastnavigation-targets
+    NAMESPACE RecastNavigation::
+    FILE recastnavigation-targets.cmake
+)
+
+install(
+    EXPORT recastnavigation-targets
+    NAMESPACE RecastNavigation::
+    FILE recastnavigation-targets.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/recastnavigation
+)
+
+install(
+    FILES
+        ${PROJECT_BINARY_DIR}/recastnavigation-config.cmake
+        ${PROJECT_BINARY_DIR}/recastnavigation-config-version.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/recastnavigation
+)
 
 if (RECASTNAVIGATION_DEMO)
     add_subdirectory(RecastDemo)

--- a/DebugUtils/CMakeLists.txt
+++ b/DebugUtils/CMakeLists.txt
@@ -24,10 +24,11 @@ set_target_properties(DebugUtils PROPERTIES
         )
 
 install(TARGETS DebugUtils
+        EXPORT recastnavigation-targets
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        COMPONENT library
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT library
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} ${CMAKE_INSTALL_INCLUDEDIR}/recastnavigation
         )
 
 file(GLOB INCLUDES Include/*.h)

--- a/Detour/CMakeLists.txt
+++ b/Detour/CMakeLists.txt
@@ -18,10 +18,11 @@ set_target_properties(Detour PROPERTIES
         )
 
 install(TARGETS Detour
+        EXPORT recastnavigation-targets
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        COMPONENT library
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT library
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} ${CMAKE_INSTALL_INCLUDEDIR}/recastnavigation
         )
 
 file(GLOB INCLUDES Include/*.h)

--- a/DetourCrowd/CMakeLists.txt
+++ b/DetourCrowd/CMakeLists.txt
@@ -22,10 +22,11 @@ set_target_properties(DetourCrowd PROPERTIES
         )
 
 install(TARGETS DetourCrowd
+        EXPORT recastnavigation-targets
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        COMPONENT library
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT library
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} ${CMAKE_INSTALL_INCLUDEDIR}/recastnavigation
         )
 
 file(GLOB INCLUDES Include/*.h)

--- a/DetourTileCache/CMakeLists.txt
+++ b/DetourTileCache/CMakeLists.txt
@@ -23,10 +23,11 @@ set_target_properties(DetourTileCache PROPERTIES
 
 
 install(TARGETS DetourTileCache
+        EXPORT recastnavigation-targets
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        COMPONENT library
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT library
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} ${CMAKE_INSTALL_INCLUDEDIR}/recastnavigation
         )
 
 file(GLOB INCLUDES Include/*.h)

--- a/Recast/CMakeLists.txt
+++ b/Recast/CMakeLists.txt
@@ -18,10 +18,11 @@ set_target_properties(Recast PROPERTIES
         )
 
 install(TARGETS Recast
+        EXPORT recastnavigation-targets
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        COMPONENT library
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT library
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} ${CMAKE_INSTALL_INCLUDEDIR}/recastnavigation
         )
 
 file(GLOB INCLUDES Include/*.h)

--- a/recastnavigation-config.cmake.in
+++ b/recastnavigation-config.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/recastnavigation-targets.cmake")


### PR DESCRIPTION
https://github.com/recastnavigation/recastnavigation/pull/358 has added ALIAS targets, but the title was misleading, ALIAS targets are only for add_subdirectory(), not find_package().

This PR installs a CMake config file containing imported targets of recastnavigation. These targets are consistent with ALIAS one: `RecastNavigation::DebugUtils`, `RecastNavigation::Detour`, `RecastNavigation::DetourCrowd`, `RecastNavigation::DetourTileCache`, `RecastNavigation::Recast`.

Thus, one can find an installation of recastnavigation and link targets, for example:

```cmake
find_package(recastnavigation REQUIRED)
target_link_libraries(foo PRIVATE RecastNavigation::Recast RecastNavigation::Detour)
```

```
mdkir build & cd build
cmake .. -DCMAKE_PREFIX_PATH=<path/to/recastnavigation/install/dir>
```

(it can also work against build tree of recastnavigation)