### PR TITLE
Cleanup Rasterization Code

### DIFF
--- a/Recast/Include/Recast.h
+++ b/Recast/Include/Recast.h
@@ -842,11 +842,14 @@ void rcClearUnwalkableTriangles(rcContext* ctx, const float walkableSlopeAngle, 
 ///  @param[in]		area			The area id of the span. [Limit: <= #RC_WALKABLE_AREA)
 ///  @param[in]		flagMergeThr	The merge theshold. [Limit: >= 0] [Units: vx]
 ///  @returns True if the operation completed successfully.
-bool rcAddSpan(rcContext* ctx, rcHeightfield& hf, const int x, const int y,
-			   const unsigned short smin, const unsigned short smax,
-			   const unsigned char area, const int flagMergeThr);
+bool rcAddSpan(rcContext* ctx, rcHeightfield& hf,
+	           int x, int y,
+               unsigned short smin, unsigned short smax,
+               unsigned char area, int flagMergeThr);
 
-/// Rasterizes a triangle into the specified heightfield.
+/// Rasterizes a single triangle into the specified heightfield.
+///
+/// Calling this for each triangle in a mesh is less efficient than calling rcRasterizeTriangles
 ///
 /// No spans will be added if the triangle does not overlap the heightfield grid.
 ///
@@ -861,9 +864,9 @@ bool rcAddSpan(rcContext* ctx, rcHeightfield& hf, const int x, const int y,
 ///  @param[in]		flagMergeThr	The distance where the walkable flag is favored over the non-walkable flag.
 ///  								[Limit: >= 0] [Units: vx]
 ///  @returns True if the operation completed successfully.
-bool rcRasterizeTriangle(rcContext* ctx, const float* v0, const float* v1, const float* v2,
-						 const unsigned char area, rcHeightfield& solid,
-						 const int flagMergeThr = 1);
+bool rcRasterizeTriangle(rcContext* ctx,
+                         const float* v0, const float* v1, const float* v2,
+                         unsigned char area, rcHeightfield& solid, int flagMergeThr = 1);
 
 /// Rasterizes an indexed triangle mesh into the specified heightfield.
 ///
@@ -881,9 +884,10 @@ bool rcRasterizeTriangle(rcContext* ctx, const float* v0, const float* v1, const
 ///  @param[in]		flagMergeThr	The distance where the walkable flag is favored over the non-walkable flag. 
 ///  								[Limit: >= 0] [Units: vx]
 ///  @returns True if the operation completed successfully.
-bool rcRasterizeTriangles(rcContext* ctx, const float* verts, const int nv,
-						  const int* tris, const unsigned char* areas, const int nt,
-						  rcHeightfield& solid, const int flagMergeThr = 1);
+bool rcRasterizeTriangles(rcContext* ctx,
+                          const float* verts, int nv,
+                          const int* tris, const unsigned char* areas, int nt,
+                          rcHeightfield& solid, int flagMergeThr = 1);
 
 /// Rasterizes an indexed triangle mesh into the specified heightfield.
 ///
@@ -901,11 +905,14 @@ bool rcRasterizeTriangles(rcContext* ctx, const float* verts, const int nv,
 ///  @param[in]		flagMergeThr	The distance where the walkable flag is favored over the non-walkable flag. 
 ///  							[Limit: >= 0] [Units: vx]
 ///  @returns True if the operation completed successfully.
-bool rcRasterizeTriangles(rcContext* ctx, const float* verts, const int nv,
-						  const unsigned short* tris, const unsigned char* areas, const int nt,
-						  rcHeightfield& solid, const int flagMergeThr = 1);
+bool rcRasterizeTriangles(rcContext* ctx,
+                          const float* verts, int nv,
+                          const unsigned short* tris, const unsigned char* areas, int nt,
+                          rcHeightfield& solid, int flagMergeThr = 1);
 
-/// Rasterizes triangles into the specified heightfield.
+/// Rasterizes a triangle list into the specified heightfield.
+///
+/// Expects each triangle to be specified as three sequential vertices of 3 floats.
 ///
 /// Spans will only be added for triangles that overlap the heightfield grid.
 /// 
@@ -919,8 +926,9 @@ bool rcRasterizeTriangles(rcContext* ctx, const float* verts, const int nv,
 ///  @param[in]		flagMergeThr	The distance where the walkable flag is favored over the non-walkable flag. 
 ///  								[Limit: >= 0] [Units: vx]
 ///  @returns True if the operation completed successfully.
-bool rcRasterizeTriangles(rcContext* ctx, const float* verts, const unsigned char* areas, const int nt,
-						  rcHeightfield& solid, const int flagMergeThr = 1);
+bool rcRasterizeTriangles(rcContext* ctx,
+                          const float* verts, const unsigned char* areas, int nt,
+                          rcHeightfield& solid, int flagMergeThr = 1);
 
 /// Marks non-walkable spans as walkable if their maximum is within @p walkableClimp of a walkable neighbor. 
 ///  @ingroup recast

--- a/Recast/Include/Recast.h
+++ b/Recast/Include/Recast.h
@@ -624,11 +624,14 @@ template<class T> inline T rcAbs(T a) { return a < 0 ? -a : a; }
 template<class T> inline T rcSqr(T a) { return a*a; }
 
 /// Clamps the value to the specified range.
-///  @param[in]		v	The value to clamp.
-///  @param[in]		mn	The minimum permitted return value.
-///  @param[in]		mx	The maximum permitted return value.
+///  @param[in]		value	The value to clamp.
+///  @param[in]		minInclusive	The minimum permitted return value.
+///  @param[in]		maxInclusive	The maximum permitted return value.
 ///  @return The value, clamped to the specified range.
-template<class T> inline T rcClamp(T v, T mn, T mx) { return v < mn ? mn : (v > mx ? mx : v); }
+template<class T> inline T rcClamp(T value, T minInclusive, T maxInclusive)
+{
+	return value < minInclusive ? minInclusive: (value > maxInclusive ? maxInclusive : value);
+}
 
 /// Returns the square root of the value.
 ///  @param[in]		x	The value.

--- a/Recast/Include/Recast.h
+++ b/Recast/Include/Recast.h
@@ -827,7 +827,7 @@ void rcClearUnwalkableTriangles(rcContext* ctx, const float walkableSlopeAngle, 
 /// Adds a span to the specified heightfield.
 /// 
 /// The span addition can be set to favor flags. If the span is merged to
-/// another span and the new @p smax is within @p flagMergeThr units
+/// another span and the new @p spanMax is within @p flagMergeThreshold units
 /// from the existing span, the span flags are merged.
 /// 
 ///  @ingroup recast
@@ -837,10 +837,10 @@ void rcClearUnwalkableTriangles(rcContext* ctx, const float walkableSlopeAngle, 
 ///  									[Limits: 0 <= value < rcHeightfield::width]
 ///  @param[in]		y					The height index where the span is to be added.
 ///  									[Limits: 0 <= value < rcHeightfield::height]
-///  @param[in]		spanMin				The minimum height of the span. [Limit: < @p smax] [Units: vx]
+///  @param[in]		spanMin				The minimum height of the span. [Limit: < @p spanMax] [Units: vx]
 ///  @param[in]		spanMax				The maximum height of the span. [Limit: <= #RC_SPAN_MAX_HEIGHT] [Units: vx]
 ///  @param[in]		areaID				The area id of the span. [Limit: <= #RC_WALKABLE_AREA)
-///  @param[in]		flagMergeThreshold	The merge theshold. [Limit: >= 0] [Units: vx]
+///  @param[in]		flagMergeThreshold	The merge threshold. [Limit: >= 0] [Units: vx]
 ///  @returns True if the operation completed successfully.
 bool rcAddSpan(rcContext* context, rcHeightfield& heightfield,
 	           int x, int y,

--- a/Recast/Include/Recast.h
+++ b/Recast/Include/Recast.h
@@ -822,6 +822,11 @@ void rcClearUnwalkableTriangles(rcContext* ctx, const float walkableSlopeAngle, 
 								const int* tris, int nt, unsigned char* areas); 
 
 /// Adds a span to the specified heightfield.
+/// 
+/// The span addition can be set to favor flags. If the span is merged to
+/// another span and the new @p smax is within @p flagMergeThr units
+/// from the existing span, the span flags are merged.
+/// 
 ///  @ingroup recast
 ///  @param[in,out]	ctx				The build context to use during the operation.
 ///  @param[in,out]	hf				An initialized heightfield.
@@ -839,6 +844,10 @@ bool rcAddSpan(rcContext* ctx, rcHeightfield& hf, const int x, const int y,
 			   const unsigned char area, const int flagMergeThr);
 
 /// Rasterizes a triangle into the specified heightfield.
+///
+/// No spans will be added if the triangle does not overlap the heightfield grid.
+///
+/// @see rcHeightfield
 ///  @ingroup recast
 ///  @param[in,out]	ctx				The build context to use during the operation.
 ///  @param[in]		v0				Triangle vertex 0 [(x, y, z)]
@@ -854,6 +863,10 @@ bool rcRasterizeTriangle(rcContext* ctx, const float* v0, const float* v1, const
 						 const int flagMergeThr = 1);
 
 /// Rasterizes an indexed triangle mesh into the specified heightfield.
+///
+/// Spans will only be added for triangles that overlap the heightfield grid.
+/// 
+///  @see rcHeightfield
 ///  @ingroup recast
 ///  @param[in,out]	ctx				The build context to use during the operation.
 ///  @param[in]		verts			The vertices. [(x, y, z) * @p nv]
@@ -870,6 +883,10 @@ bool rcRasterizeTriangles(rcContext* ctx, const float* verts, const int nv,
 						  rcHeightfield& solid, const int flagMergeThr = 1);
 
 /// Rasterizes an indexed triangle mesh into the specified heightfield.
+///
+/// Spans will only be added for triangles that overlap the heightfield grid.
+/// 
+///  @see rcHeightfield
 ///  @ingroup recast
 ///  @param[in,out]	ctx			The build context to use during the operation.
 ///  @param[in]		verts		The vertices. [(x, y, z) * @p nv]
@@ -886,6 +903,10 @@ bool rcRasterizeTriangles(rcContext* ctx, const float* verts, const int nv,
 						  rcHeightfield& solid, const int flagMergeThr = 1);
 
 /// Rasterizes triangles into the specified heightfield.
+///
+/// Spans will only be added for triangles that overlap the heightfield grid.
+/// 
+///  @see rcHeightfield
 ///  @ingroup recast
 ///  @param[in,out]	ctx				The build context to use during the operation.
 ///  @param[in]		verts			The triangle vertices. [(ax, ay, az, bx, by, bz, cx, by, cx) * @p nt]

--- a/Recast/Include/Recast.h
+++ b/Recast/Include/Recast.h
@@ -831,21 +831,21 @@ void rcClearUnwalkableTriangles(rcContext* ctx, const float walkableSlopeAngle, 
 /// from the existing span, the span flags are merged.
 /// 
 ///  @ingroup recast
-///  @param[in,out]	ctx				The build context to use during the operation.
-///  @param[in,out]	hf				An initialized heightfield.
-///  @param[in]		x				The width index where the span is to be added.
-///  								[Limits: 0 <= value < rcHeightfield::width]
-///  @param[in]		y				The height index where the span is to be added.
-///  								[Limits: 0 <= value < rcHeightfield::height]
-///  @param[in]		smin			The minimum height of the span. [Limit: < @p smax] [Units: vx]
-///  @param[in]		smax			The maximum height of the span. [Limit: <= #RC_SPAN_MAX_HEIGHT] [Units: vx]
-///  @param[in]		area			The area id of the span. [Limit: <= #RC_WALKABLE_AREA)
-///  @param[in]		flagMergeThr	The merge theshold. [Limit: >= 0] [Units: vx]
+///  @param[in,out]	context				The build context to use during the operation.
+///  @param[in,out]	heightfield			An initialized heightfield.
+///  @param[in]		x					The width index where the span is to be added.
+///  									[Limits: 0 <= value < rcHeightfield::width]
+///  @param[in]		y					The height index where the span is to be added.
+///  									[Limits: 0 <= value < rcHeightfield::height]
+///  @param[in]		spanMin				The minimum height of the span. [Limit: < @p smax] [Units: vx]
+///  @param[in]		spanMax				The maximum height of the span. [Limit: <= #RC_SPAN_MAX_HEIGHT] [Units: vx]
+///  @param[in]		areaID				The area id of the span. [Limit: <= #RC_WALKABLE_AREA)
+///  @param[in]		flagMergeThreshold	The merge theshold. [Limit: >= 0] [Units: vx]
 ///  @returns True if the operation completed successfully.
-bool rcAddSpan(rcContext* ctx, rcHeightfield& hf,
+bool rcAddSpan(rcContext* context, rcHeightfield& heightfield,
 	           int x, int y,
-               unsigned short smin, unsigned short smax,
-               unsigned char area, int flagMergeThr);
+               unsigned short spanMin, unsigned short spanMax,
+               unsigned char areaID, int flagMergeThreshold);
 
 /// Rasterizes a single triangle into the specified heightfield.
 ///
@@ -855,18 +855,18 @@ bool rcAddSpan(rcContext* ctx, rcHeightfield& hf,
 ///
 /// @see rcHeightfield
 ///  @ingroup recast
-///  @param[in,out]	ctx				The build context to use during the operation.
-///  @param[in]		v0				Triangle vertex 0 [(x, y, z)]
-///  @param[in]		v1				Triangle vertex 1 [(x, y, z)]
-///  @param[in]		v2				Triangle vertex 2 [(x, y, z)]
-///  @param[in]		area			The area id of the triangle. [Limit: <= #RC_WALKABLE_AREA]
-///  @param[in,out]	solid			An initialized heightfield.
-///  @param[in]		flagMergeThr	The distance where the walkable flag is favored over the non-walkable flag.
-///  								[Limit: >= 0] [Units: vx]
+///  @param[in,out]	context				The build context to use during the operation.
+///  @param[in]		v0					Triangle vertex 0 [(x, y, z)]
+///  @param[in]		v1					Triangle vertex 1 [(x, y, z)]
+///  @param[in]		v2					Triangle vertex 2 [(x, y, z)]
+///  @param[in]		areaID				The area id of the triangle. [Limit: <= #RC_WALKABLE_AREA]
+///  @param[in,out]	heightfield			An initialized heightfield.
+///  @param[in]		flagMergeThreshold	The distance where the walkable flag is favored over the non-walkable flag.
+///  									[Limit: >= 0] [Units: vx]
 ///  @returns True if the operation completed successfully.
-bool rcRasterizeTriangle(rcContext* ctx,
+bool rcRasterizeTriangle(rcContext* context,
                          const float* v0, const float* v1, const float* v2,
-                         unsigned char area, rcHeightfield& solid, int flagMergeThr = 1);
+                         unsigned char areaID, rcHeightfield& heightfield, int flagMergeThreshold = 1);
 
 /// Rasterizes an indexed triangle mesh into the specified heightfield.
 ///
@@ -874,20 +874,20 @@ bool rcRasterizeTriangle(rcContext* ctx,
 /// 
 ///  @see rcHeightfield
 ///  @ingroup recast
-///  @param[in,out]	ctx				The build context to use during the operation.
-///  @param[in]		verts			The vertices. [(x, y, z) * @p nv]
-///  @param[in]		nv				The number of vertices.
-///  @param[in]		tris			The triangle indices. [(vertA, vertB, vertC) * @p nt]
-///  @param[in]		areas			The area id's of the triangles. [Limit: <= #RC_WALKABLE_AREA] [Size: @p nt]
-///  @param[in]		nt				The number of triangles.
-///  @param[in,out]	solid			An initialized heightfield.
-///  @param[in]		flagMergeThr	The distance where the walkable flag is favored over the non-walkable flag. 
-///  								[Limit: >= 0] [Units: vx]
+///  @param[in,out]	context				The build context to use during the operation.
+///  @param[in]		verts				The vertices. [(x, y, z) * @p nv]
+///  @param[in]		numVerts			The number of vertices. (unused) TODO (graham): Remove in next major release
+///  @param[in]		tris				The triangle indices. [(vertA, vertB, vertC) * @p nt]
+///  @param[in]		areaIDs				The area id's of the triangles. [Limit: <= #RC_WALKABLE_AREA] [Size: @p nt]
+///  @param[in]		numTris				The number of triangles.
+///  @param[in,out]	heightfield			An initialized heightfield.
+///  @param[in]		flagMergeThreshold	The distance where the walkable flag is favored over the non-walkable flag. 
+///										[Limit: >= 0] [Units: vx]
 ///  @returns True if the operation completed successfully.
-bool rcRasterizeTriangles(rcContext* ctx,
-                          const float* verts, int nv,
-                          const int* tris, const unsigned char* areas, int nt,
-                          rcHeightfield& solid, int flagMergeThr = 1);
+bool rcRasterizeTriangles(rcContext* context,
+                          const float* verts, int numVerts,
+                          const int* tris, const unsigned char* areaIDs, int numTris,
+                          rcHeightfield& heightfield, int flagMergeThreshold = 1);
 
 /// Rasterizes an indexed triangle mesh into the specified heightfield.
 ///
@@ -895,20 +895,20 @@ bool rcRasterizeTriangles(rcContext* ctx,
 /// 
 ///  @see rcHeightfield
 ///  @ingroup recast
-///  @param[in,out]	ctx			The build context to use during the operation.
-///  @param[in]		verts		The vertices. [(x, y, z) * @p nv]
-///  @param[in]		nv			The number of vertices.
-///  @param[in]		tris		The triangle indices. [(vertA, vertB, vertC) * @p nt]
-///  @param[in]		areas		The area id's of the triangles. [Limit: <= #RC_WALKABLE_AREA] [Size: @p nt]
-///  @param[in]		nt			The number of triangles.
-///  @param[in,out]	solid		An initialized heightfield.
-///  @param[in]		flagMergeThr	The distance where the walkable flag is favored over the non-walkable flag. 
-///  							[Limit: >= 0] [Units: vx]
+///  @param[in,out]	context				The build context to use during the operation.
+///  @param[in]		verts				The vertices. [(x, y, z) * @p nv]
+///  @param[in]		numVerts			The number of vertices. (unused) TODO (graham): Remove in next major release
+///  @param[in]		tris				The triangle indices. [(vertA, vertB, vertC) * @p nt]
+///  @param[in]		areaIDs				The area id's of the triangles. [Limit: <= #RC_WALKABLE_AREA] [Size: @p nt]
+///  @param[in]		numTris				The number of triangles.
+///  @param[in,out]	heightfield			An initialized heightfield.
+///  @param[in]		flagMergeThreshold	The distance where the walkable flag is favored over the non-walkable flag. 
+///  									[Limit: >= 0] [Units: vx]
 ///  @returns True if the operation completed successfully.
-bool rcRasterizeTriangles(rcContext* ctx,
-                          const float* verts, int nv,
-                          const unsigned short* tris, const unsigned char* areas, int nt,
-                          rcHeightfield& solid, int flagMergeThr = 1);
+bool rcRasterizeTriangles(rcContext* context,
+                          const float* verts, int numVerts,
+                          const unsigned short* tris, const unsigned char* areaIDs, int numTris,
+                          rcHeightfield& heightfield, int flagMergeThreshold = 1);
 
 /// Rasterizes a triangle list into the specified heightfield.
 ///
@@ -918,17 +918,17 @@ bool rcRasterizeTriangles(rcContext* ctx,
 /// 
 ///  @see rcHeightfield
 ///  @ingroup recast
-///  @param[in,out]	ctx				The build context to use during the operation.
-///  @param[in]		verts			The triangle vertices. [(ax, ay, az, bx, by, bz, cx, by, cx) * @p nt]
-///  @param[in]		areas			The area id's of the triangles. [Limit: <= #RC_WALKABLE_AREA] [Size: @p nt]
-///  @param[in]		nt				The number of triangles.
-///  @param[in,out]	solid			An initialized heightfield.
-///  @param[in]		flagMergeThr	The distance where the walkable flag is favored over the non-walkable flag. 
-///  								[Limit: >= 0] [Units: vx]
+///  @param[in,out]	context				The build context to use during the operation.
+///  @param[in]		verts				The triangle vertices. [(ax, ay, az, bx, by, bz, cx, by, cx) * @p nt]
+///  @param[in]		areaIDs				The area id's of the triangles. [Limit: <= #RC_WALKABLE_AREA] [Size: @p nt]
+///  @param[in]		numTris				The number of triangles.
+///  @param[in,out]	heightfield			An initialized heightfield.
+///  @param[in]		flagMergeThreshold	The distance where the walkable flag is favored over the non-walkable flag. 
+///  									[Limit: >= 0] [Units: vx]
 ///  @returns True if the operation completed successfully.
-bool rcRasterizeTriangles(rcContext* ctx,
-                          const float* verts, const unsigned char* areas, int nt,
-                          rcHeightfield& solid, int flagMergeThr = 1);
+bool rcRasterizeTriangles(rcContext* context,
+                          const float* verts, const unsigned char* areaIDs, int numTris,
+                          rcHeightfield& heightfield, int flagMergeThreshold = 1);
 
 /// Marks non-walkable spans as walkable if their maximum is within @p walkableClimp of a walkable neighbor. 
 ///  @ingroup recast

--- a/Recast/Source/RecastRasterization.cpp
+++ b/Recast/Source/RecastRasterization.cpp
@@ -220,6 +220,23 @@ static void dividePoly(const float* in, int nin,
 	*nout2 = n;
 }
 
+///	Rasterize a single triangle to the heightfield.
+///
+///
+///	This code is extremely hot, so much care should be given to maintaining maximum perf here.
+/// 
+/// @param v0 Triangle vertex 0
+/// @param v1 Triangle vertex 1
+/// @param v2 Triangle vertex 2
+/// @param area The area ID to assign to the rasterized spans.
+/// @param hf Heightfield to rasterize into
+/// @param bmin The min extents of the heightfield bounding box.
+/// @param bmax The max extents of the heightfield bounding box.
+/// @param cs The x and z axis size of a voxel in the heightfield.
+/// @param ics 1 / cs
+/// @param ich 1 / ch
+/// @param flagMergeThr The threshold in which area flags will be merged. 
+/// @returns true if the operation completes successfully.  false if there was an error adding spans to the heightfield.
 static bool rasterizeTri(const float* v0, const float* v1, const float* v2,
 						 const unsigned char area, rcHeightfield& hf,
 						 const float* bmin, const float* bmax,

--- a/Recast/Source/RecastRasterization.cpp
+++ b/Recast/Source/RecastRasterization.cpp
@@ -74,8 +74,8 @@ static void freeSpan(rcHeightfield& hf, rcSpan* ptr)
 }
 
 static bool addSpan(rcHeightfield& hf, const int x, const int y,
-					const unsigned short smin, const unsigned short smax,
-					const unsigned char area, const int flagMergeThr)
+                    const unsigned short smin, const unsigned short smax,
+                    const unsigned char area, const int flagMergeThr)
 {
 	
 	int idx = x + y*hf.width;
@@ -150,8 +150,8 @@ static bool addSpan(rcHeightfield& hf, const int x, const int y,
 }
 
 bool rcAddSpan(rcContext* ctx, rcHeightfield& hf, const int x, const int y,
-			   const unsigned short smin, const unsigned short smax,
-			   const unsigned char area, const int flagMergeThr)
+               const unsigned short smin, const unsigned short smax,
+               const unsigned char area, const int flagMergeThr)
 {
 	rcAssert(ctx);
 
@@ -238,10 +238,10 @@ static void dividePoly(const float* in, int nin,
 /// @param flagMergeThr The threshold in which area flags will be merged. 
 /// @returns true if the operation completes successfully.  false if there was an error adding spans to the heightfield.
 static bool rasterizeTri(const float* v0, const float* v1, const float* v2,
-						 const unsigned char area, rcHeightfield& hf,
-						 const float* bmin, const float* bmax,
-						 const float cs, const float ics, const float ich,
-						 const int flagMergeThr)
+                         const unsigned char area, rcHeightfield& hf,
+                         const float* bmin, const float* bmax,
+                         const float cs, const float ics, const float ich,
+                         const int flagMergeThr)
 {
 	const int w = hf.width;
 	const int h = hf.height;
@@ -338,8 +338,8 @@ static bool rasterizeTri(const float* v0, const float* v1, const float* v2,
 }
 
 bool rcRasterizeTriangle(rcContext* ctx, const float* v0, const float* v1, const float* v2,
-						 const unsigned char area, rcHeightfield& solid,
-						 const int flagMergeThr)
+                         const unsigned char area, rcHeightfield& solid,
+                         const int flagMergeThr)
 {
 	rcAssert(ctx);
 
@@ -357,8 +357,8 @@ bool rcRasterizeTriangle(rcContext* ctx, const float* v0, const float* v1, const
 }
 
 bool rcRasterizeTriangles(rcContext* ctx, const float* verts, const int /*nv*/,
-						  const int* tris, const unsigned char* areas, const int nt,
-						  rcHeightfield& solid, const int flagMergeThr)
+                          const int* tris, const unsigned char* areas, const int nt,
+                          rcHeightfield& solid, const int flagMergeThr)
 {
 	rcAssert(ctx);
 
@@ -384,8 +384,8 @@ bool rcRasterizeTriangles(rcContext* ctx, const float* verts, const int /*nv*/,
 }
 
 bool rcRasterizeTriangles(rcContext* ctx, const float* verts, const int /*nv*/,
-						  const unsigned short* tris, const unsigned char* areas, const int nt,
-						  rcHeightfield& solid, const int flagMergeThr)
+                          const unsigned short* tris, const unsigned char* areas, const int nt,
+                          rcHeightfield& solid, const int flagMergeThr)
 {
 	rcAssert(ctx);
 
@@ -411,7 +411,7 @@ bool rcRasterizeTriangles(rcContext* ctx, const float* verts, const int /*nv*/,
 }
 
 bool rcRasterizeTriangles(rcContext* ctx, const float* verts, const unsigned char* areas, const int nt,
-						  rcHeightfield& solid, const int flagMergeThr)
+                          rcHeightfield& solid, const int flagMergeThr)
 {
 	rcAssert(ctx);
 	

--- a/Recast/Source/RecastRasterization.cpp
+++ b/Recast/Source/RecastRasterization.cpp
@@ -23,7 +23,7 @@
 #include "RecastAlloc.h"
 #include "RecastAssert.h"
 
-inline bool overlapBounds(const float* amin, const float* amax, const float* bmin, const float* bmax)
+static bool overlapBounds(const float* amin, const float* amax, const float* bmin, const float* bmax)
 {
 	bool overlap = true;
 	overlap = (amin[0] > bmax[0] || amax[0] < bmin[0]) ? false : overlap;

--- a/Recast/Source/RecastRasterization.cpp
+++ b/Recast/Source/RecastRasterization.cpp
@@ -40,7 +40,6 @@ inline bool overlapInterval(unsigned short amin, unsigned short amax,
 	return true;
 }
 
-
 static rcSpan* allocSpan(rcHeightfield& hf)
 {
 	// If running out of memory, allocate new page and update the freelist.
@@ -158,13 +157,6 @@ static bool addSpan(rcHeightfield& hf, const int x, const int y,
 	return true;
 }
 
-/// @par
-///
-/// The span addition can be set to favor flags. If the span is merged to
-/// another span and the new @p smax is within @p flagMergeThr units
-/// from the existing span, the span flags are merged.
-///
-/// @see rcHeightfield, rcSpan.
 bool rcAddSpan(rcContext* ctx, rcHeightfield& hf, const int x, const int y,
 			   const unsigned short smin, const unsigned short smax,
 			   const unsigned char area, const int flagMergeThr)
@@ -235,8 +227,6 @@ static void dividePoly(const float* in, int nin,
 	*nout1 = m;
 	*nout2 = n;
 }
-
-
 
 static bool rasterizeTri(const float* v0, const float* v1, const float* v2,
 						 const unsigned char area, rcHeightfield& hf,
@@ -338,11 +328,6 @@ static bool rasterizeTri(const float* v0, const float* v1, const float* v2,
 	return true;
 }
 
-/// @par
-///
-/// No spans will be added if the triangle does not overlap the heightfield grid.
-///
-/// @see rcHeightfield
 bool rcRasterizeTriangle(rcContext* ctx, const float* v0, const float* v1, const float* v2,
 						 const unsigned char area, rcHeightfield& solid,
 						 const int flagMergeThr)
@@ -362,11 +347,6 @@ bool rcRasterizeTriangle(rcContext* ctx, const float* v0, const float* v1, const
 	return true;
 }
 
-/// @par
-///
-/// Spans will only be added for triangles that overlap the heightfield grid.
-///
-/// @see rcHeightfield
 bool rcRasterizeTriangles(rcContext* ctx, const float* verts, const int /*nv*/,
 						  const int* tris, const unsigned char* areas, const int nt,
 						  rcHeightfield& solid, const int flagMergeThr)
@@ -394,11 +374,6 @@ bool rcRasterizeTriangles(rcContext* ctx, const float* verts, const int /*nv*/,
 	return true;
 }
 
-/// @par
-///
-/// Spans will only be added for triangles that overlap the heightfield grid.
-///
-/// @see rcHeightfield
 bool rcRasterizeTriangles(rcContext* ctx, const float* verts, const int /*nv*/,
 						  const unsigned short* tris, const unsigned char* areas, const int nt,
 						  rcHeightfield& solid, const int flagMergeThr)
@@ -426,11 +401,6 @@ bool rcRasterizeTriangles(rcContext* ctx, const float* verts, const int /*nv*/,
 	return true;
 }
 
-/// @par
-///
-/// Spans will only be added for triangles that overlap the heightfield grid.
-///
-/// @see rcHeightfield
 bool rcRasterizeTriangles(rcContext* ctx, const float* verts, const unsigned char* areas, const int nt,
 						  rcHeightfield& solid, const int flagMergeThr)
 {

--- a/Recast/Source/RecastRasterization.cpp
+++ b/Recast/Source/RecastRasterization.cpp
@@ -79,8 +79,16 @@ static void freeSpan(rcHeightfield& hf, rcSpan* ptr)
 	hf.freelist = ptr;
 }
 
-
-
+/// Adds a span to the heightfield.  If the new span overlaps existing spans,
+/// it will merge the new span with the existing ones.
+///
+/// @param[in]	hf					Heightfield to add spans to
+/// @param[in]	x					The new span's column cell x index
+/// @param[in]	z					The new span's column cell z index
+/// @param[in]	min					The new span's minimum cell index
+/// @param[in]	max					The new span's maximum cell index
+/// @param[in]	areaID				The new span's area type ID
+/// @param[in]	flagMergeThreshold	How close two spans maximum extents need to be to merge area type IDs
 static bool addSpan(rcHeightfield& hf,
 	const int x, const int z,
 	const unsigned short min, const unsigned short max,

--- a/Recast/Source/RecastRasterization.cpp
+++ b/Recast/Source/RecastRasterization.cpp
@@ -250,17 +250,17 @@ static void dividePoly(const float* inVerts, int inVertsCount,
 ///
 ///	This code is extremely hot, so much care should be given to maintaining maximum perf here.
 /// 
-/// @param v0 Triangle vertex 0
-/// @param v1 Triangle vertex 1
-/// @param v2 Triangle vertex 2
-/// @param area The area ID to assign to the rasterized spans.
-/// @param hf Heightfield to rasterize into
-/// @param bmin The min extents of the heightfield bounding box.
-/// @param bmax The max extents of the heightfield bounding box.
-/// @param cs The x and z axis size of a voxel in the heightfield.
-/// @param ics 1 / cs
-/// @param ich 1 / ch
-/// @param flagMergeThr The threshold in which area flags will be merged. 
+/// @param[in] 	v0				Triangle vertex 0
+/// @param[in] 	v1				Triangle vertex 1
+/// @param[in] 	v2				Triangle vertex 2
+/// @param[in] 	area			The area ID to assign to the rasterized spans
+/// @param[in] 	hf				Heightfield to rasterize into
+/// @param[in] 	bmin			The min extents of the heightfield bounding box
+/// @param[in] 	bmax			The max extents of the heightfield bounding box
+/// @param[in] 	cs				The x and z axis size of a voxel in the heightfield
+/// @param[in] 	ics				1 / cs
+/// @param[in] 	ich				1 / ch
+/// @param[in] 	flagMergeThr	The threshold in which area flags will be merged 
 /// @returns true if the operation completes successfully.  false if there was an error adding spans to the heightfield.
 static bool rasterizeTri(const float* v0, const float* v1, const float* v2,
                          const unsigned char area, rcHeightfield& hf,

--- a/Recast/Source/RecastRasterization.cpp
+++ b/Recast/Source/RecastRasterization.cpp
@@ -32,14 +32,6 @@ inline bool overlapBounds(const float* amin, const float* amax, const float* bmi
 	return overlap;
 }
 
-inline bool overlapInterval(unsigned short amin, unsigned short amax,
-							unsigned short bmin, unsigned short bmax)
-{
-	if (amax < bmin) return false;
-	if (amin > bmax) return false;
-	return true;
-}
-
 static rcSpan* allocSpan(rcHeightfield& hf)
 {
 	// If running out of memory, allocate new page and update the freelist.

--- a/Recast/Source/RecastRasterization.cpp
+++ b/Recast/Source/RecastRasterization.cpp
@@ -23,13 +23,19 @@
 #include "RecastAlloc.h"
 #include "RecastAssert.h"
 
-static bool overlapBounds(const float* amin, const float* amax, const float* bmin, const float* bmax)
+/// Check whether two bounding boxes overlap
+///
+/// @param[in]	aMin	Min axis extents of bounding box A
+/// @param[in]	aMax	Max axis extents of bounding box A
+/// @param[in]	bMin	Min axis extents of bounding box B
+/// @param[in]	bMax	Max axis extents of bounding box B
+/// @returns true if the two bounding boxes overlap.  False otherwise.
+static bool overlapBounds(const float* aMin, const float* aMax, const float* bMin, const float* bMax)
 {
-	bool overlap = true;
-	overlap = (amin[0] > bmax[0] || amax[0] < bmin[0]) ? false : overlap;
-	overlap = (amin[1] > bmax[1] || amax[1] < bmin[1]) ? false : overlap;
-	overlap = (amin[2] > bmax[2] || amax[2] < bmin[2]) ? false : overlap;
-	return overlap;
+	return
+		aMin[0] <= bMax[0] && aMax[0] >= bMin[0] &&
+		aMin[1] <= bMax[1] && aMax[1] >= bMin[1] &&
+		aMin[2] <= bMax[2] && aMax[2] >= bMin[2];
 }
 
 static rcSpan* allocSpan(rcHeightfield& hf)

--- a/Recast/Source/RecastRasterization.cpp
+++ b/Recast/Source/RecastRasterization.cpp
@@ -190,16 +190,16 @@ static bool addSpan(rcHeightfield& hf,
 	return true;
 }
 
-bool rcAddSpan(rcContext* ctx, rcHeightfield& hf,
+bool rcAddSpan(rcContext* context, rcHeightfield& heightfield,
                const int x, const int y,
-               const unsigned short smin, const unsigned short smax,
-               const unsigned char area, const int flagMergeThr)
+               const unsigned short spanMin, const unsigned short spanMax,
+               const unsigned char areaID, const int flagMergeThreshold)
 {
-	rcAssert(ctx);
+	rcAssert(context);
 
-	if (!addSpan(hf, x, y, smin, smax, area, flagMergeThr))
+	if (!addSpan(heightfield, x, y, spanMin, spanMax, areaID, flagMergeThreshold))
 	{
-		ctx->log(RC_LOG_ERROR, "rcAddSpan: Out of memory.");
+		context->log(RC_LOG_ERROR, "rcAddSpan: Out of memory.");
 		return false;
 	}
 
@@ -456,46 +456,46 @@ static bool rasterizeTri(const float* v0, const float* v1, const float* v2,
 	return true;
 }
 
-bool rcRasterizeTriangle(rcContext* ctx,
+bool rcRasterizeTriangle(rcContext* context,
                          const float* v0, const float* v1, const float* v2,
-                         const unsigned char area, rcHeightfield& solid, const int flagMergeThr)
+                         const unsigned char areaID, rcHeightfield& heightfield, const int flagMergeThreshold)
 {
-	rcAssert(ctx);
+	rcAssert(context != NULL);
 
-	rcScopedTimer timer(ctx, RC_TIMER_RASTERIZE_TRIANGLES);
+	rcScopedTimer timer(context, RC_TIMER_RASTERIZE_TRIANGLES);
 
 	// Rasterize the single triangle.
-	const float inverseCellSize = 1.0f / solid.cs;
-	const float inverseCellHeight = 1.0f / solid.ch;
-	if (!rasterizeTri(v0, v1, v2, area, solid, solid.bmin, solid.bmax, solid.cs, inverseCellSize, inverseCellHeight, flagMergeThr))
+	const float inverseCellSize = 1.0f / heightfield.cs;
+	const float inverseCellHeight = 1.0f / heightfield.ch;
+	if (!rasterizeTri(v0, v1, v2, areaID, heightfield, heightfield.bmin, heightfield.bmax, heightfield.cs, inverseCellSize, inverseCellHeight, flagMergeThreshold))
 	{
-		ctx->log(RC_LOG_ERROR, "rcRasterizeTriangle: Out of memory.");
+		context->log(RC_LOG_ERROR, "rcRasterizeTriangle: Out of memory.");
 		return false;
 	}
 
 	return true;
 }
 
-bool rcRasterizeTriangles(rcContext* ctx,
+bool rcRasterizeTriangles(rcContext* context,
                           const float* verts, const int /*nv*/,
-                          const int* tris, const unsigned char* areas, const int nt,
-                          rcHeightfield& solid, const int flagMergeThr)
+                          const int* tris, const unsigned char* areaIDs, const int numTris,
+                          rcHeightfield& heightfield, const int flagMergeThreshold)
 {
-	rcAssert(ctx);
+	rcAssert(context != NULL);
 
-	rcScopedTimer timer(ctx, RC_TIMER_RASTERIZE_TRIANGLES);
+	rcScopedTimer timer(context, RC_TIMER_RASTERIZE_TRIANGLES);
 	
 	// Rasterize the triangles.
-	const float inverseCellSize = 1.0f / solid.cs;
-	const float inverseCellHeight = 1.0f / solid.ch;
-	for (int triIndex = 0; triIndex < nt; ++triIndex)
+	const float inverseCellSize = 1.0f / heightfield.cs;
+	const float inverseCellHeight = 1.0f / heightfield.ch;
+	for (int triIndex = 0; triIndex < numTris; ++triIndex)
 	{
 		const float* v0 = &verts[tris[triIndex * 3 + 0] * 3];
 		const float* v1 = &verts[tris[triIndex * 3 + 1] * 3];
 		const float* v2 = &verts[tris[triIndex * 3 + 2] * 3];
-		if (!rasterizeTri(v0, v1, v2, areas[triIndex], solid, solid.bmin, solid.bmax, solid.cs, inverseCellSize, inverseCellHeight, flagMergeThr))
+		if (!rasterizeTri(v0, v1, v2, areaIDs[triIndex], heightfield, heightfield.bmin, heightfield.bmax, heightfield.cs, inverseCellSize, inverseCellHeight, flagMergeThreshold))
 		{
-			ctx->log(RC_LOG_ERROR, "rcRasterizeTriangles: Out of memory.");
+			context->log(RC_LOG_ERROR, "rcRasterizeTriangles: Out of memory.");
 			return false;
 		}
 	}
@@ -503,26 +503,26 @@ bool rcRasterizeTriangles(rcContext* ctx,
 	return true;
 }
 
-bool rcRasterizeTriangles(rcContext* ctx,
+bool rcRasterizeTriangles(rcContext* context,
                           const float* verts, const int /*nv*/,
-                          const unsigned short* tris, const unsigned char* areas, const int nt,
-                          rcHeightfield& solid, const int flagMergeThr)
+                          const unsigned short* tris, const unsigned char* areaIDs, const int numTris,
+                          rcHeightfield& heightfield, const int flagMergeThreshold)
 {
-	rcAssert(ctx);
+	rcAssert(context != NULL);
 
-	rcScopedTimer timer(ctx, RC_TIMER_RASTERIZE_TRIANGLES);
+	rcScopedTimer timer(context, RC_TIMER_RASTERIZE_TRIANGLES);
 
 	// Rasterize the triangles.
-	const float inverseCellSize = 1.0f / solid.cs;
-	const float inverseCellHeight = 1.0f / solid.ch;
-	for (int triIndex = 0; triIndex < nt; ++triIndex)
+	const float inverseCellSize = 1.0f / heightfield.cs;
+	const float inverseCellHeight = 1.0f / heightfield.ch;
+	for (int triIndex = 0; triIndex < numTris; ++triIndex)
 	{
 		const float* v0 = &verts[tris[triIndex * 3 + 0] * 3];
 		const float* v1 = &verts[tris[triIndex * 3 + 1] * 3];
 		const float* v2 = &verts[tris[triIndex * 3 + 2] * 3];
-		if (!rasterizeTri(v0, v1, v2, areas[triIndex], solid, solid.bmin, solid.bmax, solid.cs, inverseCellSize, inverseCellHeight, flagMergeThr))
+		if (!rasterizeTri(v0, v1, v2, areaIDs[triIndex], heightfield, heightfield.bmin, heightfield.bmax, heightfield.cs, inverseCellSize, inverseCellHeight, flagMergeThreshold))
 		{
-			ctx->log(RC_LOG_ERROR, "rcRasterizeTriangles: Out of memory.");
+			context->log(RC_LOG_ERROR, "rcRasterizeTriangles: Out of memory.");
 			return false;
 		}
 	}
@@ -530,25 +530,25 @@ bool rcRasterizeTriangles(rcContext* ctx,
 	return true;
 }
 
-bool rcRasterizeTriangles(rcContext* ctx,
-                          const float* verts, const unsigned char* areas, const int nt,
-                          rcHeightfield& solid, const int flagMergeThr)
+bool rcRasterizeTriangles(rcContext* context,
+                          const float* verts, const unsigned char* areaIDs, const int numTris,
+                          rcHeightfield& heightfield, const int flagMergeThreshold)
 {
-	rcAssert(ctx);
+	rcAssert(context != NULL);
 
-	rcScopedTimer timer(ctx, RC_TIMER_RASTERIZE_TRIANGLES);
+	rcScopedTimer timer(context, RC_TIMER_RASTERIZE_TRIANGLES);
 	
 	// Rasterize the triangles.
-	const float inverseCellSize = 1.0f / solid.cs;
-	const float inverseCellHeight = 1.0f / solid.ch;
-	for (int triIndex = 0; triIndex < nt; ++triIndex)
+	const float inverseCellSize = 1.0f / heightfield.cs;
+	const float inverseCellHeight = 1.0f / heightfield.ch;
+	for (int triIndex = 0; triIndex < numTris; ++triIndex)
 	{
 		const float* v0 = &verts[(triIndex * 3 + 0) * 3];
 		const float* v1 = &verts[(triIndex * 3 + 1) * 3];
 		const float* v2 = &verts[(triIndex * 3 + 2) * 3];
-		if (!rasterizeTri(v0, v1, v2, areas[triIndex], solid, solid.bmin, solid.bmax, solid.cs, inverseCellSize, inverseCellHeight, flagMergeThr))
+		if (!rasterizeTri(v0, v1, v2, areaIDs[triIndex], heightfield, heightfield.bmin, heightfield.bmax, heightfield.cs, inverseCellSize, inverseCellHeight, flagMergeThreshold))
 		{
-			ctx->log(RC_LOG_ERROR, "rcRasterizeTriangles: Out of memory.");
+			context->log(RC_LOG_ERROR, "rcRasterizeTriangles: Out of memory.");
 			return false;
 		}
 	}


### PR DESCRIPTION
Mostly just improving variable names for clarity.

Removed a redundant base-case check in AddSpan that resulted in a small but measurable perf improvement due to removing a branch.  Also tightened up the bounding box overlap check so it early-outs faster, which also has a small perf improvement to rasterization times.

Updated docstrings for user-facing functions. 