### PR TITLE
Supports offmesh links between non-neighbor tiles

### DIFF
--- a/Detour/Include/DetourNavMesh.h
+++ b/Detour/Include/DetourNavMesh.h
@@ -638,6 +638,8 @@ private:
 	void connectExtLinks(dtMeshTile* tile, dtMeshTile* target, int side);
 	/// Builds external polygon links for a tile.
 	void connectExtOffMeshLinks(dtMeshTile* tile, dtMeshTile* target, int side);
+	/// Builds external polygon links for a tile, to tiles that is not a neighbor.
+	void connectExtNonNeighborOffMeshLinks(dtMeshTile *tile);
 	
 	/// Removes external links at specified side.
 	void unconnectLinks(dtMeshTile* tile, dtMeshTile* target);

--- a/Detour/Source/DetourNavMesh.cpp
+++ b/Detour/Source/DetourNavMesh.cpp
@@ -1347,7 +1347,6 @@ dtStatus dtNavMesh::removeTile(dtTileRef ref, unsigned char** data, int* dataSiz
 	{
 		for (const auto &farLinks: iter->second)
 		{
-			
 			nneis = getTilesAt(farLinks.x, farLinks.y, neis, MAX_NEIS);
 			for (int j = 0; j < nneis; ++j)
 			{

--- a/Detour/Source/DetourNavMesh.cpp
+++ b/Detour/Source/DetourNavMesh.cpp
@@ -1071,6 +1071,8 @@ dtStatus dtNavMesh::addTile(unsigned char* data, int dataSize, int flags,
 			connectExtOffMeshLinks(neis[j], tile, dtOppositeTile(i));
 		}
 	}
+
+	connectExtNonNeighborOffMeshLinks(tile);
 	
 	if (result)
 		*result = getTileRef(tile);


### PR DESCRIPTION
In some cases, a (relatively) long range nav link is required, such as making NPC moving through a zipline.
However, recast will only create links between tiles that are neighbors. 
So I implemented the feature and had it tested in my game, and in recast app.

It is a small enhancement.