### PR TITLE
Removed _USE_MATH_DEFINES directive

### DIFF
--- a/DebugUtils/Source/DebugDraw.cpp
+++ b/DebugUtils/Source/DebugDraw.cpp
@@ -16,7 +16,6 @@
 // 3. This notice may not be removed or altered from any source distribution.
 //
 
-#define _USE_MATH_DEFINES
 #include <string.h>
 #include "DebugDraw.h"
 #include "DetourMath.h"

--- a/DebugUtils/Source/RecastDebugDraw.cpp
+++ b/DebugUtils/Source/RecastDebugDraw.cpp
@@ -16,7 +16,6 @@
 // 3. This notice may not be removed or altered from any source distribution.
 //
 
-#define _USE_MATH_DEFINES
 #include <math.h>
 #include "DebugDraw.h"
 #include "RecastDebugDraw.h"

--- a/DebugUtils/Source/RecastDump.cpp
+++ b/DebugUtils/Source/RecastDump.cpp
@@ -16,7 +16,6 @@
 // 3. This notice may not be removed or altered from any source distribution.
 //
 
-#define _USE_MATH_DEFINES
 #include <math.h>
 #include <stdio.h>
 #include <stdarg.h>

--- a/DetourCrowd/Source/DetourCrowd.cpp
+++ b/DetourCrowd/Source/DetourCrowd.cpp
@@ -16,7 +16,6 @@
 // 3. This notice may not be removed or altered from any source distribution.
 //
 
-#define _USE_MATH_DEFINES
 #include <string.h>
 #include <float.h>
 #include <stdlib.h>

--- a/Recast/Source/Recast.cpp
+++ b/Recast/Source/Recast.cpp
@@ -20,7 +20,6 @@
 #include "RecastAlloc.h"
 #include "RecastAssert.h"
 
-#define _USE_MATH_DEFINES
 #include <math.h>
 #include <string.h>
 #include <stdio.h>

--- a/Recast/Source/RecastArea.cpp
+++ b/Recast/Source/RecastArea.cpp
@@ -17,7 +17,6 @@
 //
 
 #include <float.h>
-#define _USE_MATH_DEFINES
 #include <math.h>
 #include <string.h>
 #include <stdlib.h>

--- a/Recast/Source/RecastContour.cpp
+++ b/Recast/Source/RecastContour.cpp
@@ -16,7 +16,6 @@
 // 3. This notice may not be removed or altered from any source distribution.
 //
 
-#define _USE_MATH_DEFINES
 #include <math.h>
 #include <string.h>
 #include <stdio.h>

--- a/Recast/Source/RecastLayers.cpp
+++ b/Recast/Source/RecastLayers.cpp
@@ -17,7 +17,6 @@
 //
 
 #include <float.h>
-#define _USE_MATH_DEFINES
 #include <math.h>
 #include <string.h>
 #include <stdlib.h>

--- a/Recast/Source/RecastMesh.cpp
+++ b/Recast/Source/RecastMesh.cpp
@@ -16,7 +16,6 @@
 // 3. This notice may not be removed or altered from any source distribution.
 //
 
-#define _USE_MATH_DEFINES
 #include <math.h>
 #include <string.h>
 #include <stdio.h>

--- a/Recast/Source/RecastMeshDetail.cpp
+++ b/Recast/Source/RecastMeshDetail.cpp
@@ -17,7 +17,6 @@
 //
 
 #include <float.h>
-#define _USE_MATH_DEFINES
 #include <math.h>
 #include <string.h>
 #include <stdlib.h>

--- a/Recast/Source/RecastRasterization.cpp
+++ b/Recast/Source/RecastRasterization.cpp
@@ -16,7 +16,6 @@
 // 3. This notice may not be removed or altered from any source distribution.
 //
 
-#define _USE_MATH_DEFINES
 #include <math.h>
 #include <stdio.h>
 #include "Recast.h"

--- a/Recast/Source/RecastRegion.cpp
+++ b/Recast/Source/RecastRegion.cpp
@@ -17,7 +17,6 @@
 //
 
 #include <float.h>
-#define _USE_MATH_DEFINES
 #include <math.h>
 #include <string.h>
 #include <stdlib.h>

--- a/RecastDemo/Source/ConvexVolumeTool.cpp
+++ b/RecastDemo/Source/ConvexVolumeTool.cpp
@@ -16,7 +16,6 @@
 // 3. This notice may not be removed or altered from any source distribution.
 //
 
-#define _USE_MATH_DEFINES
 #include <math.h>
 #include <stdio.h>
 #include <string.h>

--- a/RecastDemo/Source/CrowdTool.cpp
+++ b/RecastDemo/Source/CrowdTool.cpp
@@ -16,7 +16,6 @@
 // 3. This notice may not be removed or altered from any source distribution.
 //
 
-#define _USE_MATH_DEFINES
 #include <math.h>
 #include <stdio.h>
 #include <string.h>

--- a/RecastDemo/Source/InputGeom.cpp
+++ b/RecastDemo/Source/InputGeom.cpp
@@ -16,7 +16,6 @@
 // 3. This notice may not be removed or altered from any source distribution.
 //
 
-#define _USE_MATH_DEFINES
 #include <math.h>
 #include <stdio.h>
 #include <ctype.h>

--- a/RecastDemo/Source/MeshLoaderObj.cpp
+++ b/RecastDemo/Source/MeshLoaderObj.cpp
@@ -20,7 +20,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <cstring>
-#define _USE_MATH_DEFINES
 #include <math.h>
 
 rcMeshLoaderObj::rcMeshLoaderObj() :

--- a/RecastDemo/Source/NavMeshPruneTool.cpp
+++ b/RecastDemo/Source/NavMeshPruneTool.cpp
@@ -16,7 +16,6 @@
 // 3. This notice may not be removed or altered from any source distribution.
 //
 
-#define _USE_MATH_DEFINES
 #include <math.h>
 #include <stdio.h>
 #include <string.h>

--- a/RecastDemo/Source/NavMeshTesterTool.cpp
+++ b/RecastDemo/Source/NavMeshTesterTool.cpp
@@ -16,7 +16,6 @@
 // 3. This notice may not be removed or altered from any source distribution.
 //
 
-#define _USE_MATH_DEFINES
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/RecastDemo/Source/OffMeshConnectionTool.cpp
+++ b/RecastDemo/Source/OffMeshConnectionTool.cpp
@@ -16,7 +16,6 @@
 // 3. This notice may not be removed or altered from any source distribution.
 //
 
-#define _USE_MATH_DEFINES
 #include <math.h>
 #include <stdio.h>
 #include <string.h>

--- a/RecastDemo/Source/Sample.cpp
+++ b/RecastDemo/Source/Sample.cpp
@@ -16,7 +16,6 @@
 // 3. This notice may not be removed or altered from any source distribution.
 //
 
-#define _USE_MATH_DEFINES
 #include <math.h>
 #include <stdio.h>
 #include "Sample.h"

--- a/RecastDemo/Source/SampleInterfaces.cpp
+++ b/RecastDemo/Source/SampleInterfaces.cpp
@@ -1,4 +1,3 @@
-#define _USE_MATH_DEFINES
 #include <math.h>
 #include <stdio.h>
 #include <stdarg.h>

--- a/RecastDemo/Source/Sample_Debug.cpp
+++ b/RecastDemo/Source/Sample_Debug.cpp
@@ -16,7 +16,6 @@
 // 3. This notice may not be removed or altered from any source distribution.
 //
 
-#define _USE_MATH_DEFINES
 #include <math.h>
 #include <stdio.h>
 #include "Sample_Debug.h"

--- a/RecastDemo/Source/Sample_SoloMesh.cpp
+++ b/RecastDemo/Source/Sample_SoloMesh.cpp
@@ -16,7 +16,6 @@
 // 3. This notice may not be removed or altered from any source distribution.
 //
 
-#define _USE_MATH_DEFINES
 #include <math.h>
 #include <stdio.h>
 #include <string.h>

--- a/RecastDemo/Source/Sample_TempObstacles.cpp
+++ b/RecastDemo/Source/Sample_TempObstacles.cpp
@@ -16,7 +16,6 @@
 // 3. This notice may not be removed or altered from any source distribution.
 //
 
-#define _USE_MATH_DEFINES
 #include <math.h>
 #include <stdio.h>
 #include <string.h>

--- a/RecastDemo/Source/Sample_TileMesh.cpp
+++ b/RecastDemo/Source/Sample_TileMesh.cpp
@@ -16,7 +16,6 @@
 // 3. This notice may not be removed or altered from any source distribution.
 //
 
-#define _USE_MATH_DEFINES
 #include <math.h>
 #include <stdio.h>
 #include <string.h>

--- a/RecastDemo/Source/imgui.cpp
+++ b/RecastDemo/Source/imgui.cpp
@@ -18,7 +18,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#define _USE_MATH_DEFINES
 #include <math.h>
 #include "imgui.h"
 

--- a/RecastDemo/Source/imguiRenderGL.cpp
+++ b/RecastDemo/Source/imguiRenderGL.cpp
@@ -16,7 +16,6 @@
 // 3. This notice may not be removed or altered from any source distribution.
 //
 
-#define _USE_MATH_DEFINES
 #include <cmath>
 #include <cstdio>
 #include "imgui.h"

--- a/RecastDemo/Source/main.cpp
+++ b/RecastDemo/Source/main.cpp
@@ -17,7 +17,6 @@
 //
 
 #include <cstdio>
-#define _USE_MATH_DEFINES
 #include <cmath>
 
 #include "SDL.h"


### PR DESCRIPTION
Since none of the `M_` prefixed constants are used anywhere in the code, this is unnecessary.  It's also Windows-specific, so these non-standard defines shouldn't be used anyway.

Ref: https://learn.microsoft.com/en-us/cpp/c-runtime-library/math-constants?view=msvc-170