### PR TITLE
More Recast code cleanup

### DIFF
--- a/Recast/Include/Recast.h
+++ b/Recast/Include/Recast.h
@@ -999,32 +999,58 @@ bool rcRasterizeTriangles(rcContext* context,
                           const float* verts, const unsigned char* triAreaIDs, int numTris,
                           rcHeightfield& heightfield, int flagMergeThreshold = 1);
 
-/// Marks non-walkable spans as walkable if their maximum is within @p walkableClimb of a walkable neighbor. 
-///  @ingroup recast
-///  @param[in,out]	ctx				The build context to use during the operation.
-///  @param[in]		walkableClimb	Maximum ledge height that is considered to still be traversable. 
-///  								[Limit: >=0] [Units: vx]
-///  @param[in,out]	solid			A fully built heightfield.  (All spans have been added.)
-void rcFilterLowHangingWalkableObstacles(rcContext* ctx, const int walkableClimb, rcHeightfield& solid);
+/// Marks non-walkable spans as walkable if their maximum is within @p walkableClimb of a walkable neighbor.
+///
+/// Allows the formation of walkable regions that will flow over low lying 
+/// objects such as curbs, and up structures such as stairways. 
+/// 
+/// Two neighboring spans are walkable if: <tt>rcAbs(currentSpan.smax - neighborSpan.smax) < waklableClimb</tt>
+/// 
+/// @warning Will override the effect of #rcFilterLedgeSpans.  So if both filters are used, call
+/// #rcFilterLedgeSpans after calling this filter. 
+///
+/// @see rcHeightfield, rcConfig
+/// 
+/// @ingroup recast
+/// @param[in,out]	context				The build context to use during the operation.
+/// @param[in]		walkableClimb	Maximum ledge height that is considered to still be traversable. 
+/// 								[Limit: >=0] [Units: vx]
+/// @param[in,out]	heightfield			A fully built heightfield.  (All spans have been added.)
+void rcFilterLowHangingWalkableObstacles(rcContext* context, int walkableClimb, rcHeightfield& heightfield);
 
-/// Marks spans that are ledges as not-walkable. 
-///  @ingroup recast
-///  @param[in,out]	ctx				The build context to use during the operation.
-///  @param[in]		walkableHeight	Minimum floor to 'ceiling' height that will still allow the floor area to 
-///  								be considered walkable. [Limit: >= 3] [Units: vx]
-///  @param[in]		walkableClimb	Maximum ledge height that is considered to still be traversable. 
-///  								[Limit: >=0] [Units: vx]
-///  @param[in,out]	solid			A fully built heightfield.  (All spans have been added.)
-void rcFilterLedgeSpans(rcContext* ctx, const int walkableHeight,
-						const int walkableClimb, rcHeightfield& solid);
+/// Marks spans that are ledges as not-walkable.
+///
+/// A ledge is a span with one or more neighbors whose maximum is further away than @p walkableClimb
+/// from the current span's maximum.
+/// This method removes the impact of the overestimation of conservative voxelization 
+/// so the resulting mesh will not have regions hanging in the air over ledges.
+/// 
+/// A span is a ledge if: <tt>rcAbs(currentSpan.smax - neighborSpan.smax) > walkableClimb</tt>
+/// 
+/// @see rcHeightfield, rcConfig
+/// 
+/// @ingroup recast
+/// @param[in,out]	context				The build context to use during the operation.
+/// @param[in]		walkableHeight	Minimum floor to 'ceiling' height that will still allow the floor area to 
+/// 								be considered walkable. [Limit: >= 3] [Units: vx]
+/// @param[in]		walkableClimb	Maximum ledge height that is considered to still be traversable. 
+/// 								[Limit: >=0] [Units: vx]
+/// @param[in,out]	heightfield			A fully built heightfield.  (All spans have been added.)
+void rcFilterLedgeSpans(rcContext* context, int walkableHeight, int walkableClimb, rcHeightfield& heightfield);
 
-/// Marks walkable spans as not walkable if the clearence above the span is less than the specified height. 
-///  @ingroup recast
-///  @param[in,out]	ctx				The build context to use during the operation.
-///  @param[in]		walkableHeight	Minimum floor to 'ceiling' height that will still allow the floor area to 
-///  								be considered walkable. [Limit: >= 3] [Units: vx]
-///  @param[in,out]	solid			A fully built heightfield.  (All spans have been added.)
-void rcFilterWalkableLowHeightSpans(rcContext* ctx, int walkableHeight, rcHeightfield& solid);
+/// Marks walkable spans as not walkable if the clearance above the span is less than the specified height.
+/// 
+/// For this filter, the clearance above the span is the distance from the span's 
+/// maximum to the next higher span's minimum. (Same grid column.)
+/// 
+/// @see rcHeightfield, rcConfig
+/// @ingroup recast
+/// 
+/// @param[in,out]	context			The build context to use during the operation.
+/// @param[in]		walkableHeight	Minimum floor to 'ceiling' height that will still allow the floor area to 
+/// 								be considered walkable. [Limit: >= 3] [Units: vx]
+/// @param[in,out]	heightfield		A fully built heightfield.  (All spans have been added.)
+void rcFilterWalkableLowHeightSpans(rcContext* context, int walkableHeight, rcHeightfield& heightfield);
 
 /// Returns the number of spans contained in the specified heightfield.
 ///  @ingroup recast

--- a/Recast/Include/Recast.h
+++ b/Recast/Include/Recast.h
@@ -134,8 +134,8 @@ public:
 	/// ctx->log(RC_LOG_ERROR, "buildTiledNavigation: Could not load '%s'", filepath);
 	/// @endcode
 	/// 
-	///  @param[in]		category	The category of the message.
-	///  @param[in]		format		The message.
+	/// @param[in]		category	The category of the message.
+	/// @param[in]		format		The message.
 	void log(const rcLogCategory category, const char* format, ...);
 
 	/// Enables or disables the performance timers.
@@ -146,16 +146,16 @@ public:
 	inline void resetTimers() { if (m_timerEnabled) doResetTimers(); }
 
 	/// Starts the specified performance timer.
-	///  @param	label	The category of the timer.
+	/// @param	label	The category of the timer.
 	inline void startTimer(const rcTimerLabel label) { if (m_timerEnabled) doStartTimer(label); }
 
 	/// Stops the specified performance timer.
-	///  @param	label	The category of the timer.
+	/// @param	label	The category of the timer.
 	inline void stopTimer(const rcTimerLabel label) { if (m_timerEnabled) doStopTimer(label); }
 
 	/// Returns the total accumulated time of the specified performance timer.
-	///  @param	label	The category of the timer.
-	///  @return The accumulated time of the timer, or -1 if timers are disabled or the timer has never been started.
+	/// @param	label	The category of the timer.
+	/// @return The accumulated time of the timer, or -1 if timers are disabled or the timer has never been started.
 	inline int getAccumulatedTime(const rcTimerLabel label) const { return m_timerEnabled ? doGetAccumulatedTime(label) : -1; }
 
 protected:
@@ -163,25 +163,25 @@ protected:
 	virtual void doResetLog();
 
 	/// Logs a message.
-	///  @param[in]		category	The category of the message.
-	///  @param[in]		msg			The formatted message.
-	///  @param[in]		len			The length of the formatted message.
+	/// @param[in]		category	The category of the message.
+	/// @param[in]		msg			The formatted message.
+	/// @param[in]		len			The length of the formatted message.
 	virtual void doLog(const rcLogCategory category, const char* msg, const int len) { rcIgnoreUnused(category); rcIgnoreUnused(msg); rcIgnoreUnused(len); }
 
 	/// Clears all timers. (Resets all to unused.)
 	virtual void doResetTimers() {}
 
 	/// Starts the specified performance timer.
-	///  @param[in]		label	The category of timer.
+	/// @param[in]		label	The category of timer.
 	virtual void doStartTimer(const rcTimerLabel label) { rcIgnoreUnused(label); }
 
 	/// Stops the specified performance timer.
-	///  @param[in]		label	The category of the timer.
+	/// @param[in]		label	The category of the timer.
 	virtual void doStopTimer(const rcTimerLabel label) { rcIgnoreUnused(label); }
 
 	/// Returns the total accumulated time of the specified performance timer.
-	///  @param[in]		label	The category of the timer.
-	///  @return The accumulated time of the timer, or -1 if timers are disabled or the timer has never been started.
+	/// @param[in]		label	The category of the timer.
+	/// @return The accumulated time of the timer, or -1 if timers are disabled or the timer has never been started.
 	virtual int doGetAccumulatedTime(const rcTimerLabel label) const { rcIgnoreUnused(label); return -1; }
 	
 	/// True if logging is enabled.
@@ -505,75 +505,75 @@ private:
 /// @{
 
 /// Allocates a heightfield object using the Recast allocator.
-///  @return A heightfield that is ready for initialization, or null on failure.
-///  @ingroup recast
-///  @see rcCreateHeightfield, rcFreeHeightField
+/// @return A heightfield that is ready for initialization, or null on failure.
+/// @ingroup recast
+/// @see rcCreateHeightfield, rcFreeHeightField
 rcHeightfield* rcAllocHeightfield();
 
 /// Frees the specified heightfield object using the Recast allocator.
-///  @param[in]		heightfield	A heightfield allocated using #rcAllocHeightfield
-///  @ingroup recast
-///  @see rcAllocHeightfield
+/// @param[in]		heightfield	A heightfield allocated using #rcAllocHeightfield
+/// @ingroup recast
+/// @see rcAllocHeightfield
 void rcFreeHeightField(rcHeightfield* heightfield);
 
 /// Allocates a compact heightfield object using the Recast allocator.
-///  @return A compact heightfield that is ready for initialization, or null on failure.
-///  @ingroup recast
-///  @see rcBuildCompactHeightfield, rcFreeCompactHeightfield
+/// @return A compact heightfield that is ready for initialization, or null on failure.
+/// @ingroup recast
+/// @see rcBuildCompactHeightfield, rcFreeCompactHeightfield
 rcCompactHeightfield* rcAllocCompactHeightfield();
 
 /// Frees the specified compact heightfield object using the Recast allocator.
-///  @param[in]		compactHeightfield		A compact heightfield allocated using #rcAllocCompactHeightfield
-///  @ingroup recast
-///  @see rcAllocCompactHeightfield
+/// @param[in]		compactHeightfield		A compact heightfield allocated using #rcAllocCompactHeightfield
+/// @ingroup recast
+/// @see rcAllocCompactHeightfield
 void rcFreeCompactHeightfield(rcCompactHeightfield* compactHeightfield);
 
 /// Allocates a heightfield layer set using the Recast allocator.
-///  @return A heightfield layer set that is ready for initialization, or null on failure.
-///  @ingroup recast
-///  @see rcBuildHeightfieldLayers, rcFreeHeightfieldLayerSet
+/// @return A heightfield layer set that is ready for initialization, or null on failure.
+/// @ingroup recast
+/// @see rcBuildHeightfieldLayers, rcFreeHeightfieldLayerSet
 rcHeightfieldLayerSet* rcAllocHeightfieldLayerSet();
 
 /// Frees the specified heightfield layer set using the Recast allocator.
-///  @param[in]		layerSet	A heightfield layer set allocated using #rcAllocHeightfieldLayerSet
-///  @ingroup recast
-///  @see rcAllocHeightfieldLayerSet
+/// @param[in]		layerSet	A heightfield layer set allocated using #rcAllocHeightfieldLayerSet
+/// @ingroup recast
+/// @see rcAllocHeightfieldLayerSet
 void rcFreeHeightfieldLayerSet(rcHeightfieldLayerSet* layerSet);
 
 /// Allocates a contour set object using the Recast allocator.
-///  @return A contour set that is ready for initialization, or null on failure.
-///  @ingroup recast
-///  @see rcBuildContours, rcFreeContourSet
+/// @return A contour set that is ready for initialization, or null on failure.
+/// @ingroup recast
+/// @see rcBuildContours, rcFreeContourSet
 rcContourSet* rcAllocContourSet();
 
 /// Frees the specified contour set using the Recast allocator.
-///  @param[in]		contourSet	A contour set allocated using #rcAllocContourSet
-///  @ingroup recast
-///  @see rcAllocContourSet
+/// @param[in]		contourSet	A contour set allocated using #rcAllocContourSet
+/// @ingroup recast
+/// @see rcAllocContourSet
 void rcFreeContourSet(rcContourSet* contourSet);
 
 /// Allocates a polygon mesh object using the Recast allocator.
-///  @return A polygon mesh that is ready for initialization, or null on failure.
-///  @ingroup recast
-///  @see rcBuildPolyMesh, rcFreePolyMesh
+/// @return A polygon mesh that is ready for initialization, or null on failure.
+/// @ingroup recast
+/// @see rcBuildPolyMesh, rcFreePolyMesh
 rcPolyMesh* rcAllocPolyMesh();
 
 /// Frees the specified polygon mesh using the Recast allocator.
-///  @param[in]		polyMesh	A polygon mesh allocated using #rcAllocPolyMesh
-///  @ingroup recast
-///  @see rcAllocPolyMesh
+/// @param[in]		polyMesh	A polygon mesh allocated using #rcAllocPolyMesh
+/// @ingroup recast
+/// @see rcAllocPolyMesh
 void rcFreePolyMesh(rcPolyMesh* polyMesh);
 
 /// Allocates a detail mesh object using the Recast allocator.
-///  @return A detail mesh that is ready for initialization, or null on failure.
-///  @ingroup recast
-///  @see rcBuildPolyMeshDetail, rcFreePolyMeshDetail
+/// @return A detail mesh that is ready for initialization, or null on failure.
+/// @ingroup recast
+/// @see rcBuildPolyMeshDetail, rcFreePolyMeshDetail
 rcPolyMeshDetail* rcAllocPolyMeshDetail();
 
 /// Frees the specified detail mesh using the Recast allocator.
-///  @param[in]		detailMesh	A detail mesh allocated using #rcAllocPolyMeshDetail
-///  @ingroup recast
-///  @see rcAllocPolyMeshDetail
+/// @param[in]		detailMesh	A detail mesh allocated using #rcAllocPolyMeshDetail
+/// @ingroup recast
+/// @see rcAllocPolyMeshDetail
 void rcFreePolyMeshDetail(rcPolyMeshDetail* detailMesh);
 
 /// @}
@@ -646,37 +646,37 @@ static const int RC_NOT_CONNECTED = 0x3f;
 /// @{
 
 /// Swaps the values of the two parameters.
-///  @param[in,out]	a	Value A
-///  @param[in,out]	b	Value B
+/// @param[in,out]	a	Value A
+/// @param[in,out]	b	Value B
 template<class T> inline void rcSwap(T& a, T& b) { T t = a; a = b; b = t; }
 
 /// Returns the minimum of two values.
-///  @param[in]		a	Value A
-///  @param[in]		b	Value B
-///  @return The minimum of the two values.
+/// @param[in]		a	Value A
+/// @param[in]		b	Value B
+/// @return The minimum of the two values.
 template<class T> inline T rcMin(T a, T b) { return a < b ? a : b; }
 
 /// Returns the maximum of two values.
-///  @param[in]		a	Value A
-///  @param[in]		b	Value B
-///  @return The maximum of the two values.
+/// @param[in]		a	Value A
+/// @param[in]		b	Value B
+/// @return The maximum of the two values.
 template<class T> inline T rcMax(T a, T b) { return a > b ? a : b; }
 
 /// Returns the absolute value.
-///  @param[in]		a	The value.
-///  @return The absolute value of the specified value.
+/// @param[in]		a	The value.
+/// @return The absolute value of the specified value.
 template<class T> inline T rcAbs(T a) { return a < 0 ? -a : a; }
 
 /// Returns the square of the value.
-///  @param[in]		a	The value.
-///  @return The square of the value.
+/// @param[in]		a	The value.
+/// @return The square of the value.
 template<class T> inline T rcSqr(T a) { return a*a; }
 
 /// Clamps the value to the specified range.
-///  @param[in]		value			The value to clamp.
-///  @param[in]		minInclusive	The minimum permitted return value.
-///  @param[in]		maxInclusive	The maximum permitted return value.
-///  @return The value, clamped to the specified range.
+/// @param[in]		value			The value to clamp.
+/// @param[in]		minInclusive	The minimum permitted return value.
+/// @param[in]		maxInclusive	The maximum permitted return value.
+/// @return The value, clamped to the specified range.
 template<class T> inline T rcClamp(T value, T minInclusive, T maxInclusive)
 {
 	return value < minInclusive ? minInclusive: (value > maxInclusive ? maxInclusive : value);
@@ -692,9 +692,9 @@ float rcSqrt(float x);
 /// @{
 
 /// Derives the cross product of two vectors. (@p v1 x @p v2)
-///  @param[out]	dest	The cross product. [(x, y, z)]
-///  @param[in]		v1		A Vector [(x, y, z)]
-///  @param[in]		v2		A vector [(x, y, z)]
+/// @param[out]		dest	The cross product. [(x, y, z)]
+/// @param[in]		v1		A Vector [(x, y, z)]
+/// @param[in]		v2		A vector [(x, y, z)]
 inline void rcVcross(float* dest, const float* v1, const float* v2)
 {
 	dest[0] = v1[1]*v2[2] - v1[2]*v2[1];
@@ -703,8 +703,8 @@ inline void rcVcross(float* dest, const float* v1, const float* v2)
 }
 
 /// Derives the dot product of two vectors. (@p v1 . @p v2)
-///  @param[in]		v1	A Vector [(x, y, z)]
-///  @param[in]		v2	A vector [(x, y, z)]
+/// @param[in]		v1	A Vector [(x, y, z)]
+/// @param[in]		v2	A vector [(x, y, z)]
 /// @return The dot product.
 inline float rcVdot(const float* v1, const float* v2)
 {
@@ -712,10 +712,10 @@ inline float rcVdot(const float* v1, const float* v2)
 }
 
 /// Performs a scaled vector addition. (@p v1 + (@p v2 * @p s))
-///  @param[out]	dest	The result vector. [(x, y, z)]
-///  @param[in]		v1		The base vector. [(x, y, z)]
-///  @param[in]		v2		The vector to scale and add to @p v1. [(x, y, z)]
-///  @param[in]		s		The amount to scale @p v2 by before adding to @p v1.
+/// @param[out]		dest	The result vector. [(x, y, z)]
+/// @param[in]		v1		The base vector. [(x, y, z)]
+/// @param[in]		v2		The vector to scale and add to @p v1. [(x, y, z)]
+/// @param[in]		s		The amount to scale @p v2 by before adding to @p v1.
 inline void rcVmad(float* dest, const float* v1, const float* v2, const float s)
 {
 	dest[0] = v1[0]+v2[0]*s;
@@ -724,9 +724,9 @@ inline void rcVmad(float* dest, const float* v1, const float* v2, const float s)
 }
 
 /// Performs a vector addition. (@p v1 + @p v2)
-///  @param[out]	dest	The result vector. [(x, y, z)]
-///  @param[in]		v1		The base vector. [(x, y, z)]
-///  @param[in]		v2		The vector to add to @p v1. [(x, y, z)]
+/// @param[out]		dest	The result vector. [(x, y, z)]
+/// @param[in]		v1		The base vector. [(x, y, z)]
+/// @param[in]		v2		The vector to add to @p v1. [(x, y, z)]
 inline void rcVadd(float* dest, const float* v1, const float* v2)
 {
 	dest[0] = v1[0]+v2[0];
@@ -735,9 +735,9 @@ inline void rcVadd(float* dest, const float* v1, const float* v2)
 }
 
 /// Performs a vector subtraction. (@p v1 - @p v2)
-///  @param[out]	dest	The result vector. [(x, y, z)]
-///  @param[in]		v1		The base vector. [(x, y, z)]
-///  @param[in]		v2		The vector to subtract from @p v1. [(x, y, z)]
+/// @param[out]		dest	The result vector. [(x, y, z)]
+/// @param[in]		v1		The base vector. [(x, y, z)]
+/// @param[in]		v2		The vector to subtract from @p v1. [(x, y, z)]
 inline void rcVsub(float* dest, const float* v1, const float* v2)
 {
 	dest[0] = v1[0]-v2[0];
@@ -746,8 +746,8 @@ inline void rcVsub(float* dest, const float* v1, const float* v2)
 }
 
 /// Selects the minimum value of each element from the specified vectors.
-///  @param[in,out]	mn	A vector.  (Will be updated with the result.) [(x, y, z)]
-///  @param[in]		v	A vector. [(x, y, z)]
+/// @param[in,out]	mn	A vector.  (Will be updated with the result.) [(x, y, z)]
+/// @param[in]		v	A vector. [(x, y, z)]
 inline void rcVmin(float* mn, const float* v)
 {
 	mn[0] = rcMin(mn[0], v[0]);
@@ -756,8 +756,8 @@ inline void rcVmin(float* mn, const float* v)
 }
 
 /// Selects the maximum value of each element from the specified vectors.
-///  @param[in,out]	mx	A vector.  (Will be updated with the result.) [(x, y, z)]
-///  @param[in]		v	A vector. [(x, y, z)]
+/// @param[in,out]	mx	A vector.  (Will be updated with the result.) [(x, y, z)]
+/// @param[in]		v	A vector. [(x, y, z)]
 inline void rcVmax(float* mx, const float* v)
 {
 	mx[0] = rcMax(mx[0], v[0]);
@@ -766,8 +766,8 @@ inline void rcVmax(float* mx, const float* v)
 }
 
 /// Performs a vector copy.
-///  @param[out]	dest	The result. [(x, y, z)]
-///  @param[in]		v		The vector to copy. [(x, y, z)]
+/// @param[out]		dest	The result. [(x, y, z)]
+/// @param[in]		v		The vector to copy. [(x, y, z)]
 inline void rcVcopy(float* dest, const float* v)
 {
 	dest[0] = v[0];
@@ -776,8 +776,8 @@ inline void rcVcopy(float* dest, const float* v)
 }
 
 /// Returns the distance between two points.
-///  @param[in]		v1	A point. [(x, y, z)]
-///  @param[in]		v2	A point. [(x, y, z)]
+/// @param[in]		v1	A point. [(x, y, z)]
+/// @param[in]		v2	A point. [(x, y, z)]
 /// @return The distance between the two points.
 inline float rcVdist(const float* v1, const float* v2)
 {
@@ -788,8 +788,8 @@ inline float rcVdist(const float* v1, const float* v2)
 }
 
 /// Returns the square of the distance between two points.
-///  @param[in]		v1	A point. [(x, y, z)]
-///  @param[in]		v2	A point. [(x, y, z)]
+/// @param[in]		v1	A point. [(x, y, z)]
+/// @param[in]		v2	A point. [(x, y, z)]
 /// @return The square of the distance between the two points.
 inline float rcVdistSqr(const float* v1, const float* v2)
 {
@@ -800,7 +800,7 @@ inline float rcVdistSqr(const float* v1, const float* v2)
 }
 
 /// Normalizes the vector.
-///  @param[in,out]	v	The vector to normalize. [(x, y, z)]
+/// @param[in,out]	v	The vector to normalize. [(x, y, z)]
 inline void rcVnormalize(float* v)
 {
 	float d = 1.0f / rcSqrt(rcSqr(v[0]) + rcSqr(v[1]) + rcSqr(v[2]));
@@ -815,20 +815,20 @@ inline void rcVnormalize(float* v)
 /// @{
 
 /// Calculates the bounding box of an array of vertices.
-///  @ingroup recast
-///  @param[in]		verts		An array of vertices. [(x, y, z) * @p nv]
-///  @param[in]		numVerts	The number of vertices in the @p verts array.
-///  @param[out]	minBounds	The minimum bounds of the AABB. [(x, y, z)] [Units: wu]
-///  @param[out]	maxBounds	The maximum bounds of the AABB. [(x, y, z)] [Units: wu]
+/// @ingroup recast
+/// @param[in]		verts		An array of vertices. [(x, y, z) * @p nv]
+/// @param[in]		numVerts	The number of vertices in the @p verts array.
+/// @param[out]		minBounds	The minimum bounds of the AABB. [(x, y, z)] [Units: wu]
+/// @param[out]		maxBounds	The maximum bounds of the AABB. [(x, y, z)] [Units: wu]
 void rcCalcBounds(const float* verts, int numVerts, float* minBounds, float* maxBounds);
 
 /// Calculates the grid size based on the bounding box and grid cell size.
-///  @ingroup recast
-///  @param[in]		minBounds	The minimum bounds of the AABB. [(x, y, z)] [Units: wu]
-///  @param[in]		maxBounds	The maximum bounds of the AABB. [(x, y, z)] [Units: wu]
-///  @param[in]		cellSize	The xz-plane cell size. [Limit: > 0] [Units: wu]
-///  @param[out]	sizeX		The width along the x-axis. [Limit: >= 0] [Units: vx]
-///  @param[out]	sizeZ		The height along the z-axis. [Limit: >= 0] [Units: vx]
+/// @ingroup recast
+/// @param[in]		minBounds	The minimum bounds of the AABB. [(x, y, z)] [Units: wu]
+/// @param[in]		maxBounds	The maximum bounds of the AABB. [(x, y, z)] [Units: wu]
+/// @param[in]		cellSize	The xz-plane cell size. [Limit: > 0] [Units: wu]
+/// @param[out]		sizeX		The width along the x-axis. [Limit: >= 0] [Units: vx]
+/// @param[out]		sizeZ		The height along the z-axis. [Limit: >= 0] [Units: vx]
 void rcCalcGridSize(const float* minBounds, const float* maxBounds, float cellSize, int* sizeX, int* sizeZ);
 
 /// Initializes a new heightfield.
@@ -881,15 +881,15 @@ void rcMarkWalkableTriangles(rcContext* context, float walkableSlopeAngle, const
 /// 
 /// @see rcHeightfield, rcClearUnwalkableTriangles, rcRasterizeTriangles
 /// 
-///  @ingroup recast
-///  @param[in,out]	context				The build context to use during the operation.
-///  @param[in]		walkableSlopeAngle	The maximum slope that is considered walkable.
-///  									[Limits: 0 <= value < 90] [Units: Degrees]
-///  @param[in]		verts				The vertices. [(x, y, z) * @p nv]
-///  @param[in]		numVerts			The number of vertices.
-///  @param[in]		tris				The triangle vertex indices. [(vertA, vertB, vertC) * @p nt]
-///  @param[in]		numTris				The number of triangles.
-///  @param[out]	triAreaIDs			The triangle area ids. [Length: >= @p nt]
+/// @ingroup recast
+/// @param[in,out]	context				The build context to use during the operation.
+/// @param[in]		walkableSlopeAngle	The maximum slope that is considered walkable.
+/// 									[Limits: 0 <= value < 90] [Units: Degrees]
+/// @param[in]		verts				The vertices. [(x, y, z) * @p nv]
+/// @param[in]		numVerts			The number of vertices.
+/// @param[in]		tris				The triangle vertex indices. [(vertA, vertB, vertC) * @p nt]
+/// @param[in]		numTris				The number of triangles.
+/// @param[out]		triAreaIDs			The triangle area ids. [Length: >= @p nt]
 void rcClearUnwalkableTriangles(rcContext* context, float walkableSlopeAngle, const float* verts, int numVerts,
 								const int* tris, int numTris, unsigned char* triAreaIDs); 
 
@@ -899,18 +899,18 @@ void rcClearUnwalkableTriangles(rcContext* context, float walkableSlopeAngle, co
 /// another span and the new @p spanMax is within @p flagMergeThreshold units
 /// from the existing span, the span flags are merged.
 /// 
-///  @ingroup recast
-///  @param[in,out]	context				The build context to use during the operation.
-///  @param[in,out]	heightfield			An initialized heightfield.
-///  @param[in]		x					The column x index where the span is to be added.
-///  									[Limits: 0 <= value < rcHeightfield::width]
-///  @param[in]		z					The column z index where the span is to be added.
-///  									[Limits: 0 <= value < rcHeightfield::height]
-///  @param[in]		spanMin				The minimum height of the span. [Limit: < @p spanMax] [Units: vx]
-///  @param[in]		spanMax				The maximum height of the span. [Limit: <= #RC_SPAN_MAX_HEIGHT] [Units: vx]
-///  @param[in]		areaID				The area id of the span. [Limit: <= #RC_WALKABLE_AREA)
-///  @param[in]		flagMergeThreshold	The merge threshold. [Limit: >= 0] [Units: vx]
-///  @returns True if the operation completed successfully.
+/// @ingroup recast
+/// @param[in,out]	context				The build context to use during the operation.
+/// @param[in,out]	heightfield			An initialized heightfield.
+/// @param[in]		x					The column x index where the span is to be added.
+/// 									[Limits: 0 <= value < rcHeightfield::width]
+/// @param[in]		z					The column z index where the span is to be added.
+/// 									[Limits: 0 <= value < rcHeightfield::height]
+/// @param[in]		spanMin				The minimum height of the span. [Limit: < @p spanMax] [Units: vx]
+/// @param[in]		spanMax				The maximum height of the span. [Limit: <= #RC_SPAN_MAX_HEIGHT] [Units: vx]
+/// @param[in]		areaID				The area id of the span. [Limit: <= #RC_WALKABLE_AREA)
+/// @param[in]		flagMergeThreshold	The merge threshold. [Limit: >= 0] [Units: vx]
+/// @returns True if the operation completed successfully.
 bool rcAddSpan(rcContext* context, rcHeightfield& heightfield,
 	           int x, int z,
                unsigned short spanMin, unsigned short spanMax,
@@ -923,16 +923,16 @@ bool rcAddSpan(rcContext* context, rcHeightfield& heightfield,
 /// No spans will be added if the triangle does not overlap the heightfield grid.
 ///
 /// @see rcHeightfield
-///  @ingroup recast
-///  @param[in,out]	context				The build context to use during the operation.
-///  @param[in]		v0					Triangle vertex 0 [(x, y, z)]
-///  @param[in]		v1					Triangle vertex 1 [(x, y, z)]
-///  @param[in]		v2					Triangle vertex 2 [(x, y, z)]
-///  @param[in]		areaID				The area id of the triangle. [Limit: <= #RC_WALKABLE_AREA]
-///  @param[in,out]	heightfield			An initialized heightfield.
-///  @param[in]		flagMergeThreshold	The distance where the walkable flag is favored over the non-walkable flag.
-///  									[Limit: >= 0] [Units: vx]
-///  @returns True if the operation completed successfully.
+/// @ingroup recast
+/// @param[in,out]	context				The build context to use during the operation.
+/// @param[in]		v0					Triangle vertex 0 [(x, y, z)]
+/// @param[in]		v1					Triangle vertex 1 [(x, y, z)]
+/// @param[in]		v2					Triangle vertex 2 [(x, y, z)]
+/// @param[in]		areaID				The area id of the triangle. [Limit: <= #RC_WALKABLE_AREA]
+/// @param[in,out]	heightfield			An initialized heightfield.
+/// @param[in]		flagMergeThreshold	The distance where the walkable flag is favored over the non-walkable flag.
+/// 									[Limit: >= 0] [Units: vx]
+/// @returns True if the operation completed successfully.
 bool rcRasterizeTriangle(rcContext* context,
                          const float* v0, const float* v1, const float* v2,
                          unsigned char areaID, rcHeightfield& heightfield, int flagMergeThreshold = 1);
@@ -941,18 +941,18 @@ bool rcRasterizeTriangle(rcContext* context,
 ///
 /// Spans will only be added for triangles that overlap the heightfield grid.
 /// 
-///  @see rcHeightfield
-///  @ingroup recast
-///  @param[in,out]	context				The build context to use during the operation.
-///  @param[in]		verts				The vertices. [(x, y, z) * @p nv]
-///  @param[in]		numVerts			The number of vertices. (unused) TODO (graham): Remove in next major release
-///  @param[in]		tris				The triangle indices. [(vertA, vertB, vertC) * @p nt]
-///  @param[in]		triAreaIDs			The area id's of the triangles. [Limit: <= #RC_WALKABLE_AREA] [Size: @p nt]
-///  @param[in]		numTris				The number of triangles.
-///  @param[in,out]	heightfield			An initialized heightfield.
-///  @param[in]		flagMergeThreshold	The distance where the walkable flag is favored over the non-walkable flag. 
+/// @see rcHeightfield
+/// @ingroup recast
+/// @param[in,out]	context				The build context to use during the operation.
+/// @param[in]		verts				The vertices. [(x, y, z) * @p nv]
+/// @param[in]		numVerts			The number of vertices. (unused) TODO (graham): Remove in next major release
+/// @param[in]		tris				The triangle indices. [(vertA, vertB, vertC) * @p nt]
+/// @param[in]		triAreaIDs			The area id's of the triangles. [Limit: <= #RC_WALKABLE_AREA] [Size: @p nt]
+/// @param[in]		numTris				The number of triangles.
+/// @param[in,out]	heightfield			An initialized heightfield.
+/// @param[in]		flagMergeThreshold	The distance where the walkable flag is favored over the non-walkable flag. 
 ///										[Limit: >= 0] [Units: vx]
-///  @returns True if the operation completed successfully.
+/// @returns True if the operation completed successfully.
 bool rcRasterizeTriangles(rcContext* context,
                           const float* verts, int numVerts,
                           const int* tris, const unsigned char* triAreaIDs, int numTris,
@@ -962,18 +962,18 @@ bool rcRasterizeTriangles(rcContext* context,
 ///
 /// Spans will only be added for triangles that overlap the heightfield grid.
 /// 
-///  @see rcHeightfield
-///  @ingroup recast
-///  @param[in,out]	context				The build context to use during the operation.
-///  @param[in]		verts				The vertices. [(x, y, z) * @p nv]
-///  @param[in]		numVerts			The number of vertices. (unused) TODO (graham): Remove in next major release
-///  @param[in]		tris				The triangle indices. [(vertA, vertB, vertC) * @p nt]
-///  @param[in]		triAreaIDs			The area id's of the triangles. [Limit: <= #RC_WALKABLE_AREA] [Size: @p nt]
-///  @param[in]		numTris				The number of triangles.
-///  @param[in,out]	heightfield			An initialized heightfield.
-///  @param[in]		flagMergeThreshold	The distance where the walkable flag is favored over the non-walkable flag. 
-///  									[Limit: >= 0] [Units: vx]
-///  @returns True if the operation completed successfully.
+/// @see rcHeightfield
+/// @ingroup recast
+/// @param[in,out]	context				The build context to use during the operation.
+/// @param[in]		verts				The vertices. [(x, y, z) * @p nv]
+/// @param[in]		numVerts			The number of vertices. (unused) TODO (graham): Remove in next major release
+/// @param[in]		tris				The triangle indices. [(vertA, vertB, vertC) * @p nt]
+/// @param[in]		triAreaIDs			The area id's of the triangles. [Limit: <= #RC_WALKABLE_AREA] [Size: @p nt]
+/// @param[in]		numTris				The number of triangles.
+/// @param[in,out]	heightfield			An initialized heightfield.
+/// @param[in]		flagMergeThreshold	The distance where the walkable flag is favored over the non-walkable flag. 
+/// 									[Limit: >= 0] [Units: vx]
+/// @returns True if the operation completed successfully.
 bool rcRasterizeTriangles(rcContext* context,
                           const float* verts, int numVerts,
                           const unsigned short* tris, const unsigned char* triAreaIDs, int numTris,
@@ -985,16 +985,16 @@ bool rcRasterizeTriangles(rcContext* context,
 ///
 /// Spans will only be added for triangles that overlap the heightfield grid.
 /// 
-///  @see rcHeightfield
-///  @ingroup recast
-///  @param[in,out]	context				The build context to use during the operation.
-///  @param[in]		verts				The triangle vertices. [(ax, ay, az, bx, by, bz, cx, by, cx) * @p nt]
-///  @param[in]		triAreaIDs			The area id's of the triangles. [Limit: <= #RC_WALKABLE_AREA] [Size: @p nt]
-///  @param[in]		numTris				The number of triangles.
-///  @param[in,out]	heightfield			An initialized heightfield.
-///  @param[in]		flagMergeThreshold	The distance where the walkable flag is favored over the non-walkable flag. 
-///  									[Limit: >= 0] [Units: vx]
-///  @returns True if the operation completed successfully.
+/// @see rcHeightfield
+/// @ingroup recast
+/// @param[in,out]	context				The build context to use during the operation.
+/// @param[in]		verts				The triangle vertices. [(ax, ay, az, bx, by, bz, cx, by, cx) * @p nt]
+/// @param[in]		triAreaIDs			The area id's of the triangles. [Limit: <= #RC_WALKABLE_AREA] [Size: @p nt]
+/// @param[in]		numTris				The number of triangles.
+/// @param[in,out]	heightfield			An initialized heightfield.
+/// @param[in]		flagMergeThreshold	The distance where the walkable flag is favored over the non-walkable flag. 
+/// 									[Limit: >= 0] [Units: vx]
+/// @returns True if the operation completed successfully.
 bool rcRasterizeTriangles(rcContext* context,
                           const float* verts, const unsigned char* triAreaIDs, int numTris,
                           rcHeightfield& heightfield, int flagMergeThreshold = 1);
@@ -1061,115 +1061,115 @@ bool rcBuildCompactHeightfield(rcContext* context, int walkableHeight, int walka
 							   rcHeightfield& heightfield, rcCompactHeightfield& compactHeightfield);
 
 /// Erodes the walkable area within the heightfield by the specified radius. 
-///  @ingroup recast
-///  @param[in,out]	ctx		The build context to use during the operation.
-///  @param[in]		radius	The radius of erosion. [Limits: 0 < value < 255] [Units: vx]
-///  @param[in,out]	chf		The populated compact heightfield to erode.
-///  @returns True if the operation completed successfully.
+/// @ingroup recast
+/// @param[in,out]	ctx		The build context to use during the operation.
+/// @param[in]		radius	The radius of erosion. [Limits: 0 < value < 255] [Units: vx]
+/// @param[in,out]	chf		The populated compact heightfield to erode.
+/// @returns True if the operation completed successfully.
 bool rcErodeWalkableArea(rcContext* ctx, int radius, rcCompactHeightfield& chf);
 
 /// Applies a median filter to walkable area types (based on area id), removing noise.
-///  @ingroup recast
-///  @param[in,out]	ctx		The build context to use during the operation.
-///  @param[in,out]	chf		A populated compact heightfield.
-///  @returns True if the operation completed successfully.
+/// @ingroup recast
+/// @param[in,out]	ctx		The build context to use during the operation.
+/// @param[in,out]	chf		A populated compact heightfield.
+/// @returns True if the operation completed successfully.
 bool rcMedianFilterWalkableArea(rcContext* ctx, rcCompactHeightfield& chf);
 
 /// Applies an area id to all spans within the specified bounding box. (AABB) 
-///  @ingroup recast
-///  @param[in,out]	ctx		The build context to use during the operation.
-///  @param[in]		bmin	The minimum of the bounding box. [(x, y, z)]
-///  @param[in]		bmax	The maximum of the bounding box. [(x, y, z)]
-///  @param[in]		areaId	The area id to apply. [Limit: <= #RC_WALKABLE_AREA]
-///  @param[in,out]	chf		A populated compact heightfield.
+/// @ingroup recast
+/// @param[in,out]	ctx		The build context to use during the operation.
+/// @param[in]		bmin	The minimum of the bounding box. [(x, y, z)]
+/// @param[in]		bmax	The maximum of the bounding box. [(x, y, z)]
+/// @param[in]		areaId	The area id to apply. [Limit: <= #RC_WALKABLE_AREA]
+/// @param[in,out]	chf		A populated compact heightfield.
 void rcMarkBoxArea(rcContext* ctx, const float* bmin, const float* bmax, unsigned char areaId,
 				   rcCompactHeightfield& chf);
 
 /// Applies the area id to the all spans within the specified convex polygon. 
-///  @ingroup recast
-///  @param[in,out]	ctx		The build context to use during the operation.
-///  @param[in]		verts	The vertices of the polygon [Fomr: (x, y, z) * @p nverts]
-///  @param[in]		nverts	The number of vertices in the polygon.
-///  @param[in]		hmin	The height of the base of the polygon.
-///  @param[in]		hmax	The height of the top of the polygon.
-///  @param[in]		areaId	The area id to apply. [Limit: <= #RC_WALKABLE_AREA]
-///  @param[in,out]	chf		A populated compact heightfield.
+/// @ingroup recast
+/// @param[in,out]	ctx		The build context to use during the operation.
+/// @param[in]		verts	The vertices of the polygon [Fomr: (x, y, z) * @p nverts]
+/// @param[in]		nverts	The number of vertices in the polygon.
+/// @param[in]		hmin	The height of the base of the polygon.
+/// @param[in]		hmax	The height of the top of the polygon.
+/// @param[in]		areaId	The area id to apply. [Limit: <= #RC_WALKABLE_AREA]
+/// @param[in,out]	chf		A populated compact heightfield.
 void rcMarkConvexPolyArea(rcContext* ctx, const float* verts, const int nverts,
 						  const float hmin, const float hmax, unsigned char areaId,
 						  rcCompactHeightfield& chf);
 
 /// Helper function to offset voncex polygons for rcMarkConvexPolyArea.
-///  @ingroup recast
-///  @param[in]		verts		The vertices of the polygon [Form: (x, y, z) * @p nverts]
-///  @param[in]		nverts		The number of vertices in the polygon.
-///  @param[in]		offset		How much to offset the polygon by. [Units: wu]
-///  @param[out]	outVerts	The offset vertices (should hold up to 2 * @p nverts) [Form: (x, y, z) * return value]
-///  @param[in]		maxOutVerts	The max number of vertices that can be stored to @p outVerts.
-///  @returns Number of vertices in the offset polygon or 0 if too few vertices in @p outVerts.
+/// @ingroup recast
+/// @param[in]		verts		The vertices of the polygon [Form: (x, y, z) * @p nverts]
+/// @param[in]		nverts		The number of vertices in the polygon.
+/// @param[in]		offset		How much to offset the polygon by. [Units: wu]
+/// @param[out]		outVerts	The offset vertices (should hold up to 2 * @p nverts) [Form: (x, y, z) * return value]
+/// @param[in]		maxOutVerts	The max number of vertices that can be stored to @p outVerts.
+/// @returns Number of vertices in the offset polygon or 0 if too few vertices in @p outVerts.
 int rcOffsetPoly(const float* verts, const int nverts, const float offset,
 				 float* outVerts, const int maxOutVerts);
 
 /// Applies the area id to all spans within the specified cylinder.
-///  @ingroup recast
-///  @param[in,out]	ctx		The build context to use during the operation.
-///  @param[in]		pos		The center of the base of the cylinder. [Form: (x, y, z)] 
-///  @param[in]		r		The radius of the cylinder.
-///  @param[in]		h		The height of the cylinder.
-///  @param[in]		areaId	The area id to apply. [Limit: <= #RC_WALKABLE_AREA]
-///  @param[in,out]	chf	A populated compact heightfield.
+/// @ingroup recast
+/// @param[in,out]	ctx		The build context to use during the operation.
+/// @param[in]		pos		The center of the base of the cylinder. [Form: (x, y, z)] 
+/// @param[in]		r		The radius of the cylinder.
+/// @param[in]		h		The height of the cylinder.
+/// @param[in]		areaId	The area id to apply. [Limit: <= #RC_WALKABLE_AREA]
+/// @param[in,out]	chf	A populated compact heightfield.
 void rcMarkCylinderArea(rcContext* ctx, const float* pos,
 						const float r, const float h, unsigned char areaId,
 						rcCompactHeightfield& chf);
 
 /// Builds the distance field for the specified compact heightfield. 
-///  @ingroup recast
-///  @param[in,out]	ctx		The build context to use during the operation.
-///  @param[in,out]	chf		A populated compact heightfield.
-///  @returns True if the operation completed successfully.
+/// @ingroup recast
+/// @param[in,out]	ctx		The build context to use during the operation.
+/// @param[in,out]	chf		A populated compact heightfield.
+/// @returns True if the operation completed successfully.
 bool rcBuildDistanceField(rcContext* ctx, rcCompactHeightfield& chf);
 
 /// Builds region data for the heightfield using watershed partitioning.
-///  @ingroup recast
-///  @param[in,out]	ctx				The build context to use during the operation.
-///  @param[in,out]	chf				A populated compact heightfield.
-///  @param[in]		borderSize		The size of the non-navigable border around the heightfield.
-///  								[Limit: >=0] [Units: vx]
-///  @param[in]		minRegionArea	The minimum number of cells allowed to form isolated island areas.
-///  								[Limit: >=0] [Units: vx].
-///  @param[in]		mergeRegionArea	Any regions with a span count smaller than this value will, if possible,
-///  								be merged with larger regions. [Limit: >=0] [Units: vx] 
-///  @returns True if the operation completed successfully.
+/// @ingroup recast
+/// @param[in,out]	ctx				The build context to use during the operation.
+/// @param[in,out]	chf				A populated compact heightfield.
+/// @param[in]		borderSize		The size of the non-navigable border around the heightfield.
+/// 								[Limit: >=0] [Units: vx]
+/// @param[in]		minRegionArea	The minimum number of cells allowed to form isolated island areas.
+/// 								[Limit: >=0] [Units: vx].
+/// @param[in]		mergeRegionArea	Any regions with a span count smaller than this value will, if possible,
+/// 								be merged with larger regions. [Limit: >=0] [Units: vx] 
+/// @returns True if the operation completed successfully.
 bool rcBuildRegions(rcContext* ctx, rcCompactHeightfield& chf, int borderSize, int minRegionArea, int mergeRegionArea);
 
 /// Builds region data for the heightfield by partitioning the heightfield in non-overlapping layers.
-///  @ingroup recast
-///  @param[in,out]	ctx				The build context to use during the operation.
-///  @param[in,out]	chf				A populated compact heightfield.
-///  @param[in]		borderSize		The size of the non-navigable border around the heightfield.
+/// @ingroup recast
+/// @param[in,out]	ctx				The build context to use during the operation.
+/// @param[in,out]	chf				A populated compact heightfield.
+/// @param[in]		borderSize		The size of the non-navigable border around the heightfield.
 ///  								[Limit: >=0] [Units: vx]
-///  @param[in]		minRegionArea	The minimum number of cells allowed to form isolated island areas.
+/// @param[in]		minRegionArea	The minimum number of cells allowed to form isolated island areas.
 ///  								[Limit: >=0] [Units: vx].
-///  @returns True if the operation completed successfully.
+/// @returns True if the operation completed successfully.
 bool rcBuildLayerRegions(rcContext* ctx, rcCompactHeightfield& chf, int borderSize, int minRegionArea);
 
 /// Builds region data for the heightfield using simple monotone partitioning.
-///  @ingroup recast 
-///  @param[in,out]	ctx				The build context to use during the operation.
-///  @param[in,out]	chf				A populated compact heightfield.
-///  @param[in]		borderSize		The size of the non-navigable border around the heightfield.
+/// @ingroup recast 
+/// @param[in,out]	ctx				The build context to use during the operation.
+/// @param[in,out]	chf				A populated compact heightfield.
+/// @param[in]		borderSize		The size of the non-navigable border around the heightfield.
 ///  								[Limit: >=0] [Units: vx]
-///  @param[in]		minRegionArea	The minimum number of cells allowed to form isolated island areas.
+/// @param[in]		minRegionArea	The minimum number of cells allowed to form isolated island areas.
 ///  								[Limit: >=0] [Units: vx].
-///  @param[in]		mergeRegionArea	Any regions with a span count smaller than this value will, if possible, 
+/// @param[in]		mergeRegionArea	Any regions with a span count smaller than this value will, if possible, 
 ///  								be merged with larger regions. [Limit: >=0] [Units: vx] 
-///  @returns True if the operation completed successfully.
+/// @returns True if the operation completed successfully.
 bool rcBuildRegionsMonotone(rcContext* ctx, rcCompactHeightfield& chf,
 							int borderSize, int minRegionArea, int mergeRegionArea);
 
 /// Sets the neighbor connection data for the specified direction.
-///  @param[in]		span			The span to update.
-///  @param[in]		direction		The direction to set. [Limits: 0 <= value < 4]
-///  @param[in]		neighborIndex	The index of the neighbor span.
+/// @param[in]		span			The span to update.
+/// @param[in]		direction		The direction to set. [Limits: 0 <= value < 4]
+/// @param[in]		neighborIndex	The index of the neighbor span.
 inline void rcSetCon(rcCompactSpan& span, int direction, int neighborIndex)
 {
 	const unsigned int shift = (unsigned int)direction * 6;
@@ -1178,10 +1178,9 @@ inline void rcSetCon(rcCompactSpan& span, int direction, int neighborIndex)
 }
 
 /// Gets neighbor connection data for the specified direction.
-///  @param[in]		span		The span to check.
-///  @param[in]		direction	The direction to check. [Limits: 0 <= value < 4]
-///  @return The neighbor connection data for the specified direction,
-///  	or #RC_NOT_CONNECTED if there is no connection.
+/// @param[in]		span		The span to check.
+/// @param[in]		direction	The direction to check. [Limits: 0 <= value < 4]
+/// @return The neighbor connection data for the specified direction, or #RC_NOT_CONNECTED if there is no connection.
 inline int rcGetCon(const rcCompactSpan& span, int direction)
 {
 	const unsigned int shift = (unsigned int)direction * 6;
@@ -1189,9 +1188,8 @@ inline int rcGetCon(const rcCompactSpan& span, int direction)
 }
 
 /// Gets the standard width (x-axis) offset for the specified direction.
-///  @param[in]		direction		The direction. [Limits: 0 <= value < 4]
-///  @return The width offset to apply to the current cell position to move
-///  	in the direction.
+/// @param[in]		direction		The direction. [Limits: 0 <= value < 4]
+/// @return The width offset to apply to the current cell position to move in the direction.
 inline int rcGetDirOffsetX(int direction)
 {
 	static const int offset[4] = { -1, 0, 1, 0, };
@@ -1200,9 +1198,8 @@ inline int rcGetDirOffsetX(int direction)
 
 // TODO (graham): Rename this to rcGetDirOffsetZ
 /// Gets the standard height (z-axis) offset for the specified direction.
-///  @param[in]		direction		The direction. [Limits: 0 <= value < 4]
-///  @return The height offset to apply to the current cell position to move
-///  	in the direction.
+/// @param[in]		direction		The direction. [Limits: 0 <= value < 4]
+/// @return The height offset to apply to the current cell position to move in the direction.
 inline int rcGetDirOffsetY(int direction)
 {
 	static const int offset[4] = { 0, 1, 0, -1 };
@@ -1210,9 +1207,9 @@ inline int rcGetDirOffsetY(int direction)
 }
 
 /// Gets the direction for the specified offset. One of x and y should be 0.
-///  @param[in]		offsetX		The x offset. [Limits: -1 <= value <= 1]
-///  @param[in]		offsetZ		The z offset. [Limits: -1 <= value <= 1]
-///  @return The direction that represents the offset.
+/// @param[in]		offsetX		The x offset. [Limits: -1 <= value <= 1]
+/// @param[in]		offsetZ		The z offset. [Limits: -1 <= value <= 1]
+/// @return The direction that represents the offset.
 inline int rcGetDirForOffset(int offsetX, int offsetZ)
 {
 	static const int dirs[5] = { 3, 0, -1, 2, 1 };
@@ -1225,42 +1222,42 @@ inline int rcGetDirForOffset(int offsetX, int offsetZ)
 /// @{
 
 /// Builds a layer set from the specified compact heightfield.
-///  @ingroup recast
-///  @param[in,out]	ctx			The build context to use during the operation.
-///  @param[in]		chf			A fully built compact heightfield.
-///  @param[in]		borderSize	The size of the non-navigable border around the heightfield. [Limit: >=0] 
-///  							[Units: vx]
-///  @param[in]		walkableHeight	Minimum floor to 'ceiling' height that will still allow the floor area 
-///  							to be considered walkable. [Limit: >= 3] [Units: vx]
-///  @param[out]	lset		The resulting layer set. (Must be pre-allocated.)
-///  @returns True if the operation completed successfully.
+/// @ingroup recast
+/// @param[in,out]	ctx				The build context to use during the operation.
+/// @param[in]		chf				A fully built compact heightfield.
+/// @param[in]		borderSize		The size of the non-navigable border around the heightfield. [Limit: >=0] 
+///  								[Units: vx]
+/// @param[in]		walkableHeight	Minimum floor to 'ceiling' height that will still allow the floor area 
+///  								to be considered walkable. [Limit: >= 3] [Units: vx]
+/// @param[out]		lset			The resulting layer set. (Must be pre-allocated.)
+/// @returns True if the operation completed successfully.
 bool rcBuildHeightfieldLayers(rcContext* ctx, rcCompactHeightfield& chf, 
 							  int borderSize, int walkableHeight,
 							  rcHeightfieldLayerSet& lset);
 
 /// Builds a contour set from the region outlines in the provided compact heightfield.
-///  @ingroup recast
-///  @param[in,out]	ctx			The build context to use during the operation.
-///  @param[in]		chf			A fully built compact heightfield.
-///  @param[in]		maxError	The maximum distance a simplified contour's border edges should deviate 
-///  							the original raw contour. [Limit: >=0] [Units: wu]
-///  @param[in]		maxEdgeLen	The maximum allowed length for contour edges along the border of the mesh. 
-///  							[Limit: >=0] [Units: vx]
-///  @param[out]	cset		The resulting contour set. (Must be pre-allocated.)
-///  @param[in]		buildFlags	The build flags. (See: #rcBuildContoursFlags)
-///  @returns True if the operation completed successfully.
+/// @ingroup recast
+/// @param[in,out]	ctx			The build context to use during the operation.
+/// @param[in]		chf			A fully built compact heightfield.
+/// @param[in]		maxError	The maximum distance a simplified contour's border edges should deviate 
+/// 							the original raw contour. [Limit: >=0] [Units: wu]
+/// @param[in]		maxEdgeLen	The maximum allowed length for contour edges along the border of the mesh. 
+/// 							[Limit: >=0] [Units: vx]
+/// @param[out]		cset		The resulting contour set. (Must be pre-allocated.)
+/// @param[in]		buildFlags	The build flags. (See: #rcBuildContoursFlags)
+/// @returns True if the operation completed successfully.
 bool rcBuildContours(rcContext* ctx, rcCompactHeightfield& chf,
 					 float maxError, int maxEdgeLen,
 					 rcContourSet& cset, int buildFlags = RC_CONTOUR_TESS_WALL_EDGES);
 
 /// Builds a polygon mesh from the provided contours.
-///  @ingroup recast
-///  @param[in,out]	ctx		The build context to use during the operation.
-///  @param[in]		cset	A fully built contour set.
-///  @param[in]		nvp		The maximum number of vertices allowed for polygons generated during the 
-///  						contour to polygon conversion process. [Limit: >= 3] 
-///  @param[out]	mesh	The resulting polygon mesh. (Must be re-allocated.)
-///  @returns True if the operation completed successfully.
+/// @ingroup recast
+/// @param[in,out]	ctx		The build context to use during the operation.
+/// @param[in]		cset	A fully built contour set.
+/// @param[in]		nvp		The maximum number of vertices allowed for polygons generated during the 
+/// 						contour to polygon conversion process. [Limit: >= 3] 
+/// @param[out]		mesh	The resulting polygon mesh. (Must be re-allocated.)
+/// @returns True if the operation completed successfully.
 bool rcBuildPolyMesh(rcContext* ctx, rcContourSet& cset, const int nvp, rcPolyMesh& mesh);
 
 /// Merges multiple polygon meshes into a single mesh.
@@ -1273,34 +1270,34 @@ bool rcBuildPolyMesh(rcContext* ctx, rcContourSet& cset, const int nvp, rcPolyMe
 bool rcMergePolyMeshes(rcContext* ctx, rcPolyMesh** meshes, const int nmeshes, rcPolyMesh& mesh);
 
 /// Builds a detail mesh from the provided polygon mesh.
-///  @ingroup recast
-///  @param[in,out]	ctx				The build context to use during the operation.
-///  @param[in]		mesh			A fully built polygon mesh.
-///  @param[in]		chf				The compact heightfield used to build the polygon mesh.
-///  @param[in]		sampleDist		Sets the distance to use when sampling the heightfield. [Limit: >=0] [Units: wu]
-///  @param[in]		sampleMaxError	The maximum distance the detail mesh surface should deviate from 
-///  								heightfield data. [Limit: >=0] [Units: wu]
-///  @param[out]	dmesh			The resulting detail mesh.  (Must be pre-allocated.)
-///  @returns True if the operation completed successfully.
+/// @ingroup recast
+/// @param[in,out]	ctx				The build context to use during the operation.
+/// @param[in]		mesh			A fully built polygon mesh.
+/// @param[in]		chf				The compact heightfield used to build the polygon mesh.
+/// @param[in]		sampleDist		Sets the distance to use when sampling the heightfield. [Limit: >=0] [Units: wu]
+/// @param[in]		sampleMaxError	The maximum distance the detail mesh surface should deviate from 
+/// 								heightfield data. [Limit: >=0] [Units: wu]
+/// @param[out]		dmesh			The resulting detail mesh.  (Must be pre-allocated.)
+/// @returns True if the operation completed successfully.
 bool rcBuildPolyMeshDetail(rcContext* ctx, const rcPolyMesh& mesh, const rcCompactHeightfield& chf,
 						   float sampleDist, float sampleMaxError,
 						   rcPolyMeshDetail& dmesh);
 
 /// Copies the poly mesh data from src to dst.
-///  @ingroup recast
-///  @param[in,out]	ctx		The build context to use during the operation.
-///  @param[in]		src		The source mesh to copy from.
-///  @param[out]	dst		The resulting detail mesh. (Must be pre-allocated, must be empty mesh.)
-///  @returns True if the operation completed successfully.
+/// @ingroup recast
+/// @param[in,out]	ctx		The build context to use during the operation.
+/// @param[in]		src		The source mesh to copy from.
+/// @param[out]		dst		The resulting detail mesh. (Must be pre-allocated, must be empty mesh.)
+/// @returns True if the operation completed successfully.
 bool rcCopyPolyMesh(rcContext* ctx, const rcPolyMesh& src, rcPolyMesh& dst);
 
 /// Merges multiple detail meshes into a single detail mesh.
-///  @ingroup recast
-///  @param[in,out]	ctx		The build context to use during the operation.
-///  @param[in]		meshes	An array of detail meshes to merge. [Size: @p nmeshes]
-///  @param[in]		nmeshes	The number of detail meshes in the meshes array.
-///  @param[out]	mesh	The resulting detail mesh. (Must be pre-allocated.)
-///  @returns True if the operation completed successfully.
+/// @ingroup recast
+/// @param[in,out]	ctx		The build context to use during the operation.
+/// @param[in]		meshes	An array of detail meshes to merge. [Size: @p nmeshes]
+/// @param[in]		nmeshes	The number of detail meshes in the meshes array.
+/// @param[out]		mesh	The resulting detail mesh. (Must be pre-allocated.)
+/// @returns True if the operation completed successfully.
 bool rcMergePolyMeshDetails(rcContext* ctx, rcPolyMeshDetail** meshes, const int nmeshes, rcPolyMeshDetail& mesh);
 
 /// @}

--- a/Recast/Include/Recast.h
+++ b/Recast/Include/Recast.h
@@ -483,12 +483,20 @@ private:
 /// @ingroup recast
 struct rcPolyMeshDetail
 {
+	rcPolyMeshDetail();
+	~rcPolyMeshDetail();
+	
 	unsigned int* meshes;	///< The sub-mesh data. [Size: 4*#nmeshes] 
 	float* verts;			///< The mesh vertices. [Size: 3*#nverts] 
 	unsigned char* tris;	///< The mesh triangles. [Size: 4*#ntris] 
 	int nmeshes;			///< The number of sub-meshes defined by #meshes.
 	int nverts;				///< The number of vertices in #verts.
 	int ntris;				///< The number of triangles in #tris.
+	
+private:
+	// Explicitly-disabled copy constructor and copy assignment operator.
+	rcPolyMeshDetail(const rcPolyMeshDetail&);
+	rcPolyMeshDetail& operator=(const rcPolyMeshDetail&);
 };
 
 /// @name Allocation Functions

--- a/Recast/Include/Recast.h
+++ b/Recast/Include/Recast.h
@@ -352,6 +352,7 @@ struct rcCompactHeightfield
 {
 	rcCompactHeightfield();
 	~rcCompactHeightfield();
+	
 	int width;					///< The width of the heightfield. (Along the x-axis in cell units.)
 	int height;					///< The height of the heightfield. (Along the z-axis in cell units.)
 	int spanCount;				///< The number of spans in the heightfield.
@@ -368,6 +369,11 @@ struct rcCompactHeightfield
 	rcCompactSpan* spans;		///< Array of spans. [Size: #spanCount]
 	unsigned short* dist;		///< Array containing border distance data. [Size: #spanCount]
 	unsigned char* areas;		///< Array containing area id data. [Size: #spanCount]
+	
+private:
+	// Explicitly-disabled copy constructor and copy assignment operator.
+	rcCompactHeightfield(const rcCompactHeightfield&);
+	rcCompactHeightfield& operator=(const rcCompactHeightfield&);
 };
 
 /// Represents a heightfield layer within a layer set.
@@ -398,8 +404,14 @@ struct rcHeightfieldLayerSet
 {
 	rcHeightfieldLayerSet();
 	~rcHeightfieldLayerSet();
+	
 	rcHeightfieldLayer* layers;			///< The layers in the set. [Size: #nlayers]
 	int nlayers;						///< The number of layers in the set.
+	
+private:
+	// Explicitly-disabled copy constructor and copy assignment operator.
+	rcHeightfieldLayerSet(const rcHeightfieldLayerSet&);
+	rcHeightfieldLayerSet& operator=(const rcHeightfieldLayerSet&);
 };
 
 /// Represents a simple, non-overlapping contour in field space.
@@ -419,6 +431,7 @@ struct rcContourSet
 {
 	rcContourSet();
 	~rcContourSet();
+	
 	rcContour* conts;	///< An array of the contours in the set. [Size: #nconts]
 	int nconts;			///< The number of contours in the set.
 	float bmin[3];  	///< The minimum bounds in world space. [(x, y, z)]
@@ -429,6 +442,11 @@ struct rcContourSet
 	int height;			///< The height of the set. (Along the z-axis in cell units.) 
 	int borderSize;		///< The AABB border size used to generate the source data from which the contours were derived.
 	float maxError;		///< The max edge error that this contour set was simplified with.
+	
+private:
+	// Explicitly-disabled copy constructor and copy assignment operator.
+	rcContourSet(const rcContourSet&);
+	rcContourSet& operator=(const rcContourSet&);
 };
 
 /// Represents a polygon mesh suitable for use in building a navigation mesh. 
@@ -437,6 +455,7 @@ struct rcPolyMesh
 {
 	rcPolyMesh();
 	~rcPolyMesh();
+	
 	unsigned short* verts;	///< The mesh vertices. [Form: (x, y, z) * #nverts]
 	unsigned short* polys;	///< Polygon and neighbor data. [Length: #maxpolys * 2 * #nvp]
 	unsigned short* regs;	///< The region id assigned to each polygon. [Length: #maxpolys]
@@ -452,6 +471,11 @@ struct rcPolyMesh
 	float ch;				///< The height of each cell. (The minimum increment along the y-axis.)
 	int borderSize;			///< The AABB border size used to generate the source data from which the mesh was derived.
 	float maxEdgeError;		///< The max error of the polygon edges in the mesh.
+	
+private:
+	// Explicitly-disabled copy constructor and copy assignment operator.
+	rcPolyMesh(const rcPolyMesh&);
+	rcPolyMesh& operator=(const rcPolyMesh&);
 };
 
 /// Contains triangle meshes that represent detailed height data associated 

--- a/Recast/Include/Recast.h
+++ b/Recast/Include/Recast.h
@@ -503,10 +503,10 @@ struct rcPolyMeshDetail
 rcHeightfield* rcAllocHeightfield();
 
 /// Frees the specified heightfield object using the Recast allocator.
-///  @param[in]		hf	A heightfield allocated using #rcAllocHeightfield
+///  @param[in]		heightfield	A heightfield allocated using #rcAllocHeightfield
 ///  @ingroup recast
 ///  @see rcAllocHeightfield
-void rcFreeHeightField(rcHeightfield* hf);
+void rcFreeHeightField(rcHeightfield* heightfield);
 
 /// Allocates a compact heightfield object using the Recast allocator.
 ///  @return A compact heightfield that is ready for initialization, or null on failure.
@@ -515,10 +515,10 @@ void rcFreeHeightField(rcHeightfield* hf);
 rcCompactHeightfield* rcAllocCompactHeightfield();
 
 /// Frees the specified compact heightfield object using the Recast allocator.
-///  @param[in]		chf		A compact heightfield allocated using #rcAllocCompactHeightfield
+///  @param[in]		compactHeightfield		A compact heightfield allocated using #rcAllocCompactHeightfield
 ///  @ingroup recast
 ///  @see rcAllocCompactHeightfield
-void rcFreeCompactHeightfield(rcCompactHeightfield* chf);
+void rcFreeCompactHeightfield(rcCompactHeightfield* compactHeightfield);
 
 /// Allocates a heightfield layer set using the Recast allocator.
 ///  @return A heightfield layer set that is ready for initialization, or null on failure.
@@ -527,10 +527,10 @@ void rcFreeCompactHeightfield(rcCompactHeightfield* chf);
 rcHeightfieldLayerSet* rcAllocHeightfieldLayerSet();
 
 /// Frees the specified heightfield layer set using the Recast allocator.
-///  @param[in]		lset	A heightfield layer set allocated using #rcAllocHeightfieldLayerSet
+///  @param[in]		layerSet	A heightfield layer set allocated using #rcAllocHeightfieldLayerSet
 ///  @ingroup recast
 ///  @see rcAllocHeightfieldLayerSet
-void rcFreeHeightfieldLayerSet(rcHeightfieldLayerSet* lset);
+void rcFreeHeightfieldLayerSet(rcHeightfieldLayerSet* layerSet);
 
 /// Allocates a contour set object using the Recast allocator.
 ///  @return A contour set that is ready for initialization, or null on failure.
@@ -539,10 +539,10 @@ void rcFreeHeightfieldLayerSet(rcHeightfieldLayerSet* lset);
 rcContourSet* rcAllocContourSet();
 
 /// Frees the specified contour set using the Recast allocator.
-///  @param[in]		cset	A contour set allocated using #rcAllocContourSet
+///  @param[in]		contourSet	A contour set allocated using #rcAllocContourSet
 ///  @ingroup recast
 ///  @see rcAllocContourSet
-void rcFreeContourSet(rcContourSet* cset);
+void rcFreeContourSet(rcContourSet* contourSet);
 
 /// Allocates a polygon mesh object using the Recast allocator.
 ///  @return A polygon mesh that is ready for initialization, or null on failure.
@@ -551,10 +551,10 @@ void rcFreeContourSet(rcContourSet* cset);
 rcPolyMesh* rcAllocPolyMesh();
 
 /// Frees the specified polygon mesh using the Recast allocator.
-///  @param[in]		pmesh	A polygon mesh allocated using #rcAllocPolyMesh
+///  @param[in]		polyMesh	A polygon mesh allocated using #rcAllocPolyMesh
 ///  @ingroup recast
 ///  @see rcAllocPolyMesh
-void rcFreePolyMesh(rcPolyMesh* pmesh);
+void rcFreePolyMesh(rcPolyMesh* polyMesh);
 
 /// Allocates a detail mesh object using the Recast allocator.
 ///  @return A detail mesh that is ready for initialization, or null on failure.
@@ -563,10 +563,10 @@ void rcFreePolyMesh(rcPolyMesh* pmesh);
 rcPolyMeshDetail* rcAllocPolyMeshDetail();
 
 /// Frees the specified detail mesh using the Recast allocator.
-///  @param[in]		dmesh	A detail mesh allocated using #rcAllocPolyMeshDetail
+///  @param[in]		detailMesh	A detail mesh allocated using #rcAllocPolyMeshDetail
 ///  @ingroup recast
 ///  @see rcAllocPolyMeshDetail
-void rcFreePolyMeshDetail(rcPolyMeshDetail* dmesh);
+void rcFreePolyMeshDetail(rcPolyMeshDetail* detailMesh);
 
 /// @}
 
@@ -665,7 +665,7 @@ template<class T> inline T rcAbs(T a) { return a < 0 ? -a : a; }
 template<class T> inline T rcSqr(T a) { return a*a; }
 
 /// Clamps the value to the specified range.
-///  @param[in]		value	The value to clamp.
+///  @param[in]		value			The value to clamp.
 ///  @param[in]		minInclusive	The minimum permitted return value.
 ///  @param[in]		maxInclusive	The maximum permitted return value.
 ///  @return The value, clamped to the specified range.
@@ -808,20 +808,20 @@ inline void rcVnormalize(float* v)
 
 /// Calculates the bounding box of an array of vertices.
 ///  @ingroup recast
-///  @param[in]		verts	An array of vertices. [(x, y, z) * @p nv]
-///  @param[in]		nv		The number of vertices in the @p verts array.
-///  @param[out]	bmin	The minimum bounds of the AABB. [(x, y, z)] [Units: wu]
-///  @param[out]	bmax	The maximum bounds of the AABB. [(x, y, z)] [Units: wu]
-void rcCalcBounds(const float* verts, int nv, float* bmin, float* bmax);
+///  @param[in]		verts		An array of vertices. [(x, y, z) * @p nv]
+///  @param[in]		numVerts	The number of vertices in the @p verts array.
+///  @param[out]	minBounds	The minimum bounds of the AABB. [(x, y, z)] [Units: wu]
+///  @param[out]	maxBounds	The maximum bounds of the AABB. [(x, y, z)] [Units: wu]
+void rcCalcBounds(const float* verts, int numVerts, float* minBounds, float* maxBounds);
 
 /// Calculates the grid size based on the bounding box and grid cell size.
 ///  @ingroup recast
-///  @param[in]		bmin	The minimum bounds of the AABB. [(x, y, z)] [Units: wu]
-///  @param[in]		bmax	The maximum bounds of the AABB. [(x, y, z)] [Units: wu]
-///  @param[in]		cs		The xz-plane cell size. [Limit: > 0] [Units: wu]
-///  @param[out]	w		The width along the x-axis. [Limit: >= 0] [Units: vx]
-///  @param[out]	h		The height along the z-axis. [Limit: >= 0] [Units: vx]
-void rcCalcGridSize(const float* bmin, const float* bmax, float cs, int* w, int* h);
+///  @param[in]		minBounds	The minimum bounds of the AABB. [(x, y, z)] [Units: wu]
+///  @param[in]		maxBounds	The maximum bounds of the AABB. [(x, y, z)] [Units: wu]
+///  @param[in]		cellSize	The xz-plane cell size. [Limit: > 0] [Units: wu]
+///  @param[out]	sizeX		The width along the x-axis. [Limit: >= 0] [Units: vx]
+///  @param[out]	sizeZ		The height along the z-axis. [Limit: >= 0] [Units: vx]
+void rcCalcGridSize(const float* minBounds, const float* maxBounds, float cellSize, int* sizeX, int* sizeZ);
 
 /// Initializes a new heightfield.
 /// See the #rcConfig documentation for more information on the configuration parameters.
@@ -829,18 +829,18 @@ void rcCalcGridSize(const float* bmin, const float* bmax, float cs, int* w, int*
 /// @see rcAllocHeightfield, rcHeightfield
 /// @ingroup recast
 /// 
-/// @param[in,out]	ctx		The build context to use during the operation.
-/// @param[in,out]	hf		The allocated heightfield to initialize.
-/// @param[in]		width	The width of the field along the x-axis. [Limit: >= 0] [Units: vx]
-/// @param[in]		height	The height of the field along the z-axis. [Limit: >= 0] [Units: vx]
-/// @param[in]		bmin	The minimum bounds of the field's AABB. [(x, y, z)] [Units: wu]
-/// @param[in]		bmax	The maximum bounds of the field's AABB. [(x, y, z)] [Units: wu]
-/// @param[in]		cs		The xz-plane cell size to use for the field. [Limit: > 0] [Units: wu]
-/// @param[in]		ch		The y-axis cell size to use for field. [Limit: > 0] [Units: wu]
+/// @param[in,out]	context		The build context to use during the operation.
+/// @param[in,out]	heightfield	The allocated heightfield to initialize.
+/// @param[in]		sizeX		The width of the field along the x-axis. [Limit: >= 0] [Units: vx]
+/// @param[in]		sizeZ		The height of the field along the z-axis. [Limit: >= 0] [Units: vx]
+/// @param[in]		minBounds	The minimum bounds of the field's AABB. [(x, y, z)] [Units: wu]
+/// @param[in]		maxBounds	The maximum bounds of the field's AABB. [(x, y, z)] [Units: wu]
+/// @param[in]		cellSize	The xz-plane cell size to use for the field. [Limit: > 0] [Units: wu]
+/// @param[in]		cellHeight	The y-axis cell size to use for field. [Limit: > 0] [Units: wu]
 /// @returns True if the operation completed successfully.
-bool rcCreateHeightfield(rcContext* ctx, rcHeightfield& hf, int width, int height,
-						 const float* bmin, const float* bmax,
-						 float cs, float ch);
+bool rcCreateHeightfield(rcContext* context, rcHeightfield& heightfield, int sizeX, int sizeZ,
+						 const float* minBounds, const float* maxBounds,
+						 float cellSize, float cellHeight);
 
 /// Sets the area id of all triangles with a slope below the specified value
 /// to #RC_WALKABLE_AREA.
@@ -853,16 +853,16 @@ bool rcCreateHeightfield(rcContext* ctx, rcHeightfield& hf, int width, int heigh
 /// @see rcHeightfield, rcClearUnwalkableTriangles, rcRasterizeTriangles
 /// 
 /// @ingroup recast
-/// @param[in,out]	ctx					The build context to use during the operation.
+/// @param[in,out]	context				The build context to use during the operation.
 /// @param[in]		walkableSlopeAngle	The maximum slope that is considered walkable.
 /// 									[Limits: 0 <= value < 90] [Units: Degrees]
 /// @param[in]		verts				The vertices. [(x, y, z) * @p nv]
-/// @param[in]		nv					The number of vertices.
+/// @param[in]		numVerts			The number of vertices.
 /// @param[in]		tris				The triangle vertex indices. [(vertA, vertB, vertC) * @p nt]
-/// @param[in]		nt					The number of triangles.
-/// @param[out]		areas				The triangle area ids. [Length: >= @p nt]
-void rcMarkWalkableTriangles(rcContext* ctx, float walkableSlopeAngle, const float* verts, int nv,
-							 const int* tris, int nt, unsigned char* areas); 
+/// @param[in]		numTris				The number of triangles.
+/// @param[out]		triAreaIDs			The triangle area ids. [Length: >= @p nt]
+void rcMarkWalkableTriangles(rcContext* context, float walkableSlopeAngle, const float* verts, int numVerts,
+							 const int* tris, int numTris, unsigned char* triAreaIDs); 
 
 /// Sets the area id of all triangles with a slope greater than or equal to the specified value to #RC_NULL_AREA.
 /// 
@@ -874,16 +874,16 @@ void rcMarkWalkableTriangles(rcContext* ctx, float walkableSlopeAngle, const flo
 /// @see rcHeightfield, rcClearUnwalkableTriangles, rcRasterizeTriangles
 /// 
 ///  @ingroup recast
-///  @param[in,out]	ctx					The build context to use during the operation.
+///  @param[in,out]	context				The build context to use during the operation.
 ///  @param[in]		walkableSlopeAngle	The maximum slope that is considered walkable.
 ///  									[Limits: 0 <= value < 90] [Units: Degrees]
 ///  @param[in]		verts				The vertices. [(x, y, z) * @p nv]
-///  @param[in]		nv					The number of vertices.
+///  @param[in]		numVerts			The number of vertices.
 ///  @param[in]		tris				The triangle vertex indices. [(vertA, vertB, vertC) * @p nt]
-///  @param[in]		nt					The number of triangles.
-///  @param[out]	areas				The triangle area ids. [Length: >= @p nt]
-void rcClearUnwalkableTriangles(rcContext* ctx, float walkableSlopeAngle, const float* verts, int nv,
-								const int* tris, int nt, unsigned char* areas); 
+///  @param[in]		numTris				The number of triangles.
+///  @param[out]	triAreaIDs			The triangle area ids. [Length: >= @p nt]
+void rcClearUnwalkableTriangles(rcContext* context, float walkableSlopeAngle, const float* verts, int numVerts,
+								const int* tris, int numTris, unsigned char* triAreaIDs); 
 
 /// Adds a span to the specified heightfield.
 /// 
@@ -894,9 +894,9 @@ void rcClearUnwalkableTriangles(rcContext* ctx, float walkableSlopeAngle, const 
 ///  @ingroup recast
 ///  @param[in,out]	context				The build context to use during the operation.
 ///  @param[in,out]	heightfield			An initialized heightfield.
-///  @param[in]		x					The width index where the span is to be added.
+///  @param[in]		x					The column x index where the span is to be added.
 ///  									[Limits: 0 <= value < rcHeightfield::width]
-///  @param[in]		y					The height index where the span is to be added.
+///  @param[in]		z					The column z index where the span is to be added.
 ///  									[Limits: 0 <= value < rcHeightfield::height]
 ///  @param[in]		spanMin				The minimum height of the span. [Limit: < @p spanMax] [Units: vx]
 ///  @param[in]		spanMax				The maximum height of the span. [Limit: <= #RC_SPAN_MAX_HEIGHT] [Units: vx]
@@ -904,7 +904,7 @@ void rcClearUnwalkableTriangles(rcContext* ctx, float walkableSlopeAngle, const 
 ///  @param[in]		flagMergeThreshold	The merge threshold. [Limit: >= 0] [Units: vx]
 ///  @returns True if the operation completed successfully.
 bool rcAddSpan(rcContext* context, rcHeightfield& heightfield,
-	           int x, int y,
+	           int x, int z,
                unsigned short spanMin, unsigned short spanMax,
                unsigned char areaID, int flagMergeThreshold);
 
@@ -939,7 +939,7 @@ bool rcRasterizeTriangle(rcContext* context,
 ///  @param[in]		verts				The vertices. [(x, y, z) * @p nv]
 ///  @param[in]		numVerts			The number of vertices. (unused) TODO (graham): Remove in next major release
 ///  @param[in]		tris				The triangle indices. [(vertA, vertB, vertC) * @p nt]
-///  @param[in]		areaIDs				The area id's of the triangles. [Limit: <= #RC_WALKABLE_AREA] [Size: @p nt]
+///  @param[in]		triAreaIDs			The area id's of the triangles. [Limit: <= #RC_WALKABLE_AREA] [Size: @p nt]
 ///  @param[in]		numTris				The number of triangles.
 ///  @param[in,out]	heightfield			An initialized heightfield.
 ///  @param[in]		flagMergeThreshold	The distance where the walkable flag is favored over the non-walkable flag. 
@@ -947,7 +947,7 @@ bool rcRasterizeTriangle(rcContext* context,
 ///  @returns True if the operation completed successfully.
 bool rcRasterizeTriangles(rcContext* context,
                           const float* verts, int numVerts,
-                          const int* tris, const unsigned char* areaIDs, int numTris,
+                          const int* tris, const unsigned char* triAreaIDs, int numTris,
                           rcHeightfield& heightfield, int flagMergeThreshold = 1);
 
 /// Rasterizes an indexed triangle mesh into the specified heightfield.
@@ -960,7 +960,7 @@ bool rcRasterizeTriangles(rcContext* context,
 ///  @param[in]		verts				The vertices. [(x, y, z) * @p nv]
 ///  @param[in]		numVerts			The number of vertices. (unused) TODO (graham): Remove in next major release
 ///  @param[in]		tris				The triangle indices. [(vertA, vertB, vertC) * @p nt]
-///  @param[in]		areaIDs				The area id's of the triangles. [Limit: <= #RC_WALKABLE_AREA] [Size: @p nt]
+///  @param[in]		triAreaIDs			The area id's of the triangles. [Limit: <= #RC_WALKABLE_AREA] [Size: @p nt]
 ///  @param[in]		numTris				The number of triangles.
 ///  @param[in,out]	heightfield			An initialized heightfield.
 ///  @param[in]		flagMergeThreshold	The distance where the walkable flag is favored over the non-walkable flag. 
@@ -968,7 +968,7 @@ bool rcRasterizeTriangles(rcContext* context,
 ///  @returns True if the operation completed successfully.
 bool rcRasterizeTriangles(rcContext* context,
                           const float* verts, int numVerts,
-                          const unsigned short* tris, const unsigned char* areaIDs, int numTris,
+                          const unsigned short* tris, const unsigned char* triAreaIDs, int numTris,
                           rcHeightfield& heightfield, int flagMergeThreshold = 1);
 
 /// Rasterizes a triangle list into the specified heightfield.
@@ -981,14 +981,14 @@ bool rcRasterizeTriangles(rcContext* context,
 ///  @ingroup recast
 ///  @param[in,out]	context				The build context to use during the operation.
 ///  @param[in]		verts				The triangle vertices. [(ax, ay, az, bx, by, bz, cx, by, cx) * @p nt]
-///  @param[in]		areaIDs				The area id's of the triangles. [Limit: <= #RC_WALKABLE_AREA] [Size: @p nt]
+///  @param[in]		triAreaIDs			The area id's of the triangles. [Limit: <= #RC_WALKABLE_AREA] [Size: @p nt]
 ///  @param[in]		numTris				The number of triangles.
 ///  @param[in,out]	heightfield			An initialized heightfield.
 ///  @param[in]		flagMergeThreshold	The distance where the walkable flag is favored over the non-walkable flag. 
 ///  									[Limit: >= 0] [Units: vx]
 ///  @returns True if the operation completed successfully.
 bool rcRasterizeTriangles(rcContext* context,
-                          const float* verts, const unsigned char* areaIDs, int numTris,
+                          const float* verts, const unsigned char* triAreaIDs, int numTris,
                           rcHeightfield& heightfield, int flagMergeThreshold = 1);
 
 /// Marks non-walkable spans as walkable if their maximum is within @p walkableClimb of a walkable neighbor. 
@@ -1020,10 +1020,10 @@ void rcFilterWalkableLowHeightSpans(rcContext* ctx, int walkableHeight, rcHeight
 
 /// Returns the number of spans contained in the specified heightfield.
 ///  @ingroup recast
-///  @param[in,out]	ctx		The build context to use during the operation.
-///  @param[in]		hf		An initialized heightfield.
+///  @param[in,out]	context		The build context to use during the operation.
+///  @param[in]		heightfield	An initialized heightfield.
 ///  @returns The number of spans in the heightfield.
-int rcGetHeightFieldSpanCount(rcContext* ctx, rcHeightfield& hf);
+int rcGetHeightFieldSpanCount(rcContext* context, const rcHeightfield& heightfield);
 
 /// @}
 /// @name Compact Heightfield Functions
@@ -1041,16 +1041,16 @@ int rcGetHeightFieldSpanCount(rcContext* ctx, rcHeightfield& hf);
 /// @see rcAllocCompactHeightfield, rcHeightfield, rcCompactHeightfield, rcConfig
 /// @ingroup recast
 /// 
-/// @param[in,out]	ctx				The build context to use during the operation.
-/// @param[in]		walkableHeight	Minimum floor to 'ceiling' height that will still allow the floor area 
-/// 								to be considered walkable. [Limit: >= 3] [Units: vx]
-/// @param[in]		walkableClimb	Maximum ledge height that is considered to still be traversable. 
-/// 								[Limit: >=0] [Units: vx]
-/// @param[in]		hf				The heightfield to be compacted.
-/// @param[out]		chf				The resulting compact heightfield. (Must be pre-allocated.)
+/// @param[in,out]	context				The build context to use during the operation.
+/// @param[in]		walkableHeight		Minimum floor to 'ceiling' height that will still allow the floor area 
+/// 									to be considered walkable. [Limit: >= 3] [Units: vx]
+/// @param[in]		walkableClimb		Maximum ledge height that is considered to still be traversable. 
+/// 									[Limit: >=0] [Units: vx]
+/// @param[in]		heightfield			The heightfield to be compacted.
+/// @param[out]		compactHeightfield	The resulting compact heightfield. (Must be pre-allocated.)
 /// @returns True if the operation completed successfully.
-bool rcBuildCompactHeightfield(rcContext* ctx, const int walkableHeight, const int walkableClimb,
-							   rcHeightfield& hf, rcCompactHeightfield& chf);
+bool rcBuildCompactHeightfield(rcContext* context, int walkableHeight, int walkableClimb,
+							   rcHeightfield& heightfield, rcCompactHeightfield& compactHeightfield);
 
 /// Erodes the walkable area within the heightfield by the specified radius. 
 ///  @ingroup recast
@@ -1128,11 +1128,10 @@ bool rcBuildDistanceField(rcContext* ctx, rcCompactHeightfield& chf);
 ///  								[Limit: >=0] [Units: vx]
 ///  @param[in]		minRegionArea	The minimum number of cells allowed to form isolated island areas.
 ///  								[Limit: >=0] [Units: vx].
-///  @param[in]		mergeRegionArea		Any regions with a span count smaller than this value will, if possible,
+///  @param[in]		mergeRegionArea	Any regions with a span count smaller than this value will, if possible,
 ///  								be merged with larger regions. [Limit: >=0] [Units: vx] 
 ///  @returns True if the operation completed successfully.
-bool rcBuildRegions(rcContext* ctx, rcCompactHeightfield& chf,
-					const int borderSize, const int minRegionArea, const int mergeRegionArea);
+bool rcBuildRegions(rcContext* ctx, rcCompactHeightfield& chf, int borderSize, int minRegionArea, int mergeRegionArea);
 
 /// Builds region data for the heightfield by partitioning the heightfield in non-overlapping layers.
 ///  @ingroup recast
@@ -1143,8 +1142,7 @@ bool rcBuildRegions(rcContext* ctx, rcCompactHeightfield& chf,
 ///  @param[in]		minRegionArea	The minimum number of cells allowed to form isolated island areas.
 ///  								[Limit: >=0] [Units: vx].
 ///  @returns True if the operation completed successfully.
-bool rcBuildLayerRegions(rcContext* ctx, rcCompactHeightfield& chf,
-						 const int borderSize, const int minRegionArea);
+bool rcBuildLayerRegions(rcContext* ctx, rcCompactHeightfield& chf, int borderSize, int minRegionArea);
 
 /// Builds region data for the heightfield using simple monotone partitioning.
 ///  @ingroup recast 
@@ -1158,58 +1156,59 @@ bool rcBuildLayerRegions(rcContext* ctx, rcCompactHeightfield& chf,
 ///  								be merged with larger regions. [Limit: >=0] [Units: vx] 
 ///  @returns True if the operation completed successfully.
 bool rcBuildRegionsMonotone(rcContext* ctx, rcCompactHeightfield& chf,
-							const int borderSize, const int minRegionArea, const int mergeRegionArea);
+							int borderSize, int minRegionArea, int mergeRegionArea);
 
 /// Sets the neighbor connection data for the specified direction.
-///  @param[in]		s		The span to update.
-///  @param[in]		dir		The direction to set. [Limits: 0 <= value < 4]
-///  @param[in]		i		The index of the neighbor span.
-inline void rcSetCon(rcCompactSpan& s, int dir, int i)
+///  @param[in]		span			The span to update.
+///  @param[in]		direction		The direction to set. [Limits: 0 <= value < 4]
+///  @param[in]		neighborIndex	The index of the neighbor span.
+inline void rcSetCon(rcCompactSpan& span, int direction, int neighborIndex)
 {
-	const unsigned int shift = (unsigned int)dir*6;
-	const unsigned int con = s.con;
-	s.con = (con & ~(0x3f << shift)) | (((unsigned int)i & 0x3f) << shift);
+	const unsigned int shift = (unsigned int)direction * 6;
+	const unsigned int con = span.con;
+	span.con = (con & ~(0x3f << shift)) | (((unsigned int)neighborIndex & 0x3f) << shift);
 }
 
 /// Gets neighbor connection data for the specified direction.
-///  @param[in]		s		The span to check.
-///  @param[in]		dir		The direction to check. [Limits: 0 <= value < 4]
+///  @param[in]		span		The span to check.
+///  @param[in]		direction	The direction to check. [Limits: 0 <= value < 4]
 ///  @return The neighbor connection data for the specified direction,
 ///  	or #RC_NOT_CONNECTED if there is no connection.
-inline int rcGetCon(const rcCompactSpan& s, int dir)
+inline int rcGetCon(const rcCompactSpan& span, int direction)
 {
-	const unsigned int shift = (unsigned int)dir*6;
-	return (s.con >> shift) & 0x3f;
+	const unsigned int shift = (unsigned int)direction * 6;
+	return (span.con >> shift) & 0x3f;
 }
 
 /// Gets the standard width (x-axis) offset for the specified direction.
-///  @param[in]		dir		The direction. [Limits: 0 <= value < 4]
+///  @param[in]		direction		The direction. [Limits: 0 <= value < 4]
 ///  @return The width offset to apply to the current cell position to move
 ///  	in the direction.
-inline int rcGetDirOffsetX(int dir)
+inline int rcGetDirOffsetX(int direction)
 {
 	static const int offset[4] = { -1, 0, 1, 0, };
-	return offset[dir&0x03];
+	return offset[direction & 0x03];
 }
 
+// TODO (graham): Rename this to rcGetDirOffsetZ
 /// Gets the standard height (z-axis) offset for the specified direction.
-///  @param[in]		dir		The direction. [Limits: 0 <= value < 4]
+///  @param[in]		direction		The direction. [Limits: 0 <= value < 4]
 ///  @return The height offset to apply to the current cell position to move
 ///  	in the direction.
-inline int rcGetDirOffsetY(int dir)
+inline int rcGetDirOffsetY(int direction)
 {
 	static const int offset[4] = { 0, 1, 0, -1 };
-	return offset[dir&0x03];
+	return offset[direction & 0x03];
 }
 
 /// Gets the direction for the specified offset. One of x and y should be 0.
-///  @param[in]		x		The x offset. [Limits: -1 <= value <= 1]
-///  @param[in]		y		The y offset. [Limits: -1 <= value <= 1]
+///  @param[in]		offsetX		The x offset. [Limits: -1 <= value <= 1]
+///  @param[in]		offsetZ		The z offset. [Limits: -1 <= value <= 1]
 ///  @return The direction that represents the offset.
-inline int rcGetDirForOffset(int x, int y)
+inline int rcGetDirForOffset(int offsetX, int offsetZ)
 {
 	static const int dirs[5] = { 3, 0, -1, 2, 1 };
-	return dirs[((y+1)<<1)+x];
+	return dirs[((offsetZ + 1) << 1) + offsetX];
 }
 
 /// @}
@@ -1228,7 +1227,7 @@ inline int rcGetDirForOffset(int x, int y)
 ///  @param[out]	lset		The resulting layer set. (Must be pre-allocated.)
 ///  @returns True if the operation completed successfully.
 bool rcBuildHeightfieldLayers(rcContext* ctx, rcCompactHeightfield& chf, 
-							  const int borderSize, const int walkableHeight,
+							  int borderSize, int walkableHeight,
 							  rcHeightfieldLayerSet& lset);
 
 /// Builds a contour set from the region outlines in the provided compact heightfield.
@@ -1243,8 +1242,8 @@ bool rcBuildHeightfieldLayers(rcContext* ctx, rcCompactHeightfield& chf,
 ///  @param[in]		buildFlags	The build flags. (See: #rcBuildContoursFlags)
 ///  @returns True if the operation completed successfully.
 bool rcBuildContours(rcContext* ctx, rcCompactHeightfield& chf,
-					 const float maxError, const int maxEdgeLen,
-					 rcContourSet& cset, const int buildFlags = RC_CONTOUR_TESS_WALL_EDGES);
+					 float maxError, int maxEdgeLen,
+					 rcContourSet& cset, int buildFlags = RC_CONTOUR_TESS_WALL_EDGES);
 
 /// Builds a polygon mesh from the provided contours.
 ///  @ingroup recast
@@ -1276,7 +1275,7 @@ bool rcMergePolyMeshes(rcContext* ctx, rcPolyMesh** meshes, const int nmeshes, r
 ///  @param[out]	dmesh			The resulting detail mesh.  (Must be pre-allocated.)
 ///  @returns True if the operation completed successfully.
 bool rcBuildPolyMeshDetail(rcContext* ctx, const rcPolyMesh& mesh, const rcCompactHeightfield& chf,
-						   const float sampleDist, const float sampleMaxError,
+						   float sampleDist, float sampleMaxError,
 						   rcPolyMeshDetail& dmesh);
 
 /// Copies the poly mesh data from src to dst.

--- a/Recast/Include/RecastAlloc.h
+++ b/Recast/Include/RecastAlloc.h
@@ -19,10 +19,9 @@
 #ifndef RECASTALLOC_H
 #define RECASTALLOC_H
 
-#include <stddef.h>
-#include <stdint.h>
-
 #include "RecastAssert.h"
+
+#include <stdint.h>
 
 /// Provides hint values to the memory allocator on how long the
 /// memory is expected to be used.
@@ -47,18 +46,27 @@ typedef void (rcFreeFunc)(void* ptr);
 /// Sets the base custom allocation functions to be used by Recast.
 ///  @param[in]		allocFunc	The memory allocation function to be used by #rcAlloc
 ///  @param[in]		freeFunc	The memory de-allocation function to be used by #rcFree
+///  
+/// @see rcAlloc, rcFree
 void rcAllocSetCustom(rcAllocFunc *allocFunc, rcFreeFunc *freeFunc);
 
 /// Allocates a memory block.
-///  @param[in]		size	The size, in bytes of memory, to allocate.
-///  @param[in]		hint	A hint to the allocator on how long the memory is expected to be in use.
-///  @return A pointer to the beginning of the allocated memory block, or null if the allocation failed.
-/// @see rcFree
+/// 
+/// @param[in]		size	The size, in bytes of memory, to allocate.
+/// @param[in]		hint	A hint to the allocator on how long the memory is expected to be in use.
+/// @return A pointer to the beginning of the allocated memory block, or null if the allocation failed.
+/// 
+/// @see rcFree, rcAllocSetCustom
 void* rcAlloc(size_t size, rcAllocHint hint);
 
-/// Deallocates a memory block.
-///  @param[in]		ptr		A pointer to a memory block previously allocated using #rcAlloc.
-/// @see rcAlloc
+/// Deallocates a memory block.  If @p ptr is NULL, this does nothing.
+///
+/// @warning This function leaves the value of @p ptr unchanged.  So it still
+/// points to the same (now invalid) location, and not to null.
+/// 
+/// @param[in]		ptr		A pointer to a memory block previously allocated using #rcAlloc.
+/// 
+/// @see rcAlloc, rcAllocSetCustom
 void rcFree(void* ptr);
 
 /// An implementation of operator new usable for placement new. The default one is part of STL (which we don't use).

--- a/Recast/Include/RecastAlloc.h
+++ b/Recast/Include/RecastAlloc.h
@@ -21,6 +21,7 @@
 
 #include "RecastAssert.h"
 
+#include <stdlib.h>
 #include <stdint.h>
 
 /// Provides hint values to the memory allocator on how long the

--- a/Recast/Include/RecastAssert.h
+++ b/Recast/Include/RecastAssert.h
@@ -19,13 +19,10 @@
 #ifndef RECASTASSERT_H
 #define RECASTASSERT_H
 
-// Note: This header file's only purpose is to include define assert.
-// Feel free to change the file and include your own implementation instead.
-
 #ifdef NDEBUG
 
 // From http://cnicholson.net/2009/02/stupid-c-tricks-adventures-in-assert/
-#	define rcAssert(x) do { (void)sizeof(x); } while((void)(__LINE__==-1),false)
+#	define rcAssert(x) do { (void)sizeof(x); } while ((void)(__LINE__==-1), false)
 
 #else
 
@@ -38,7 +35,7 @@ typedef void (rcAssertFailFunc)(const char* expression, const char* file, int li
 
 /// Sets the base custom assertion failure function to be used by Recast.
 ///  @param[in]		assertFailFunc	The function to be used in case of failure of #dtAssert
-void rcAssertFailSetCustom(rcAssertFailFunc *assertFailFunc);
+void rcAssertFailSetCustom(rcAssertFailFunc* assertFailFunc);
 
 /// Gets the base custom assertion failure function to be used by Recast.
 rcAssertFailFunc* rcAssertFailGetCustom();
@@ -47,8 +44,8 @@ rcAssertFailFunc* rcAssertFailGetCustom();
 #	define rcAssert(expression) \
 		{ \
 			rcAssertFailFunc* failFunc = rcAssertFailGetCustom(); \
-			if(failFunc == NULL) { assert(expression); } \
-			else if(!(expression)) { (*failFunc)(#expression, __FILE__, __LINE__); } \
+			if (failFunc == NULL) { assert(expression); } \
+			else if (!(expression)) { (*failFunc)(#expression, __FILE__, __LINE__); } \
 		}
 
 #endif

--- a/Recast/Source/Recast.cpp
+++ b/Recast/Source/Recast.cpp
@@ -16,81 +16,67 @@
 // 3. This notice may not be removed or altered from any source distribution.
 //
 
-#include <float.h>
-#define _USE_MATH_DEFINES
-#include <math.h>
-#include <string.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <stdarg.h>
 #include "Recast.h"
 #include "RecastAlloc.h"
 #include "RecastAssert.h"
+
+#define _USE_MATH_DEFINES
+#include <math.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdarg.h>
 
 namespace
 {
 /// Allocates and constructs an object of the given type, returning a pointer.
 /// TODO: Support constructor args.
-/// @param[in]		hint	Hint to the allocator.
-template <typename T>
-T* rcNew(rcAllocHint hint) {
-	T* ptr = (T*)rcAlloc(sizeof(T), hint);
+/// @param[in]		allocLifetime	Allocation lifetime hint
+template<typename T>
+T* rcNew(const rcAllocHint allocLifetime)
+{
+	T* ptr = (T*)rcAlloc(sizeof(T), allocLifetime);
 	::new(rcNewTag(), (void*)ptr) T();
 	return ptr;
 }
 
 /// Destroys and frees an object allocated with rcNew.
 /// @param[in]     ptr    The object pointer to delete.
-template <typename T>
-void rcDelete(T* ptr) {
-	if (ptr) {
+template<typename T>
+void rcDelete(T* ptr)
+{
+	if (ptr)
+	{
 		ptr->~T();
 		rcFree((void*)ptr);
 	}
 }
-}  // namespace
-
+} // anonymous namespace
 
 float rcSqrt(float x)
 {
 	return sqrtf(x);
 }
 
-/// @class rcContext
-/// @par
-///
-/// This class does not provide logging or timer functionality on its 
-/// own.  Both must be provided by a concrete implementation 
-/// by overriding the protected member functions.  Also, this class does not 
-/// provide an interface for extracting log messages. (Only adding them.) 
-/// So concrete implementations must provide one.
-///
-/// If no logging or timers are required, just pass an instance of this 
-/// class through the Recast build process.
-///
-
-/// @par
-///
-/// Example:
-/// @code
-/// // Where ctx is an instance of rcContext and filepath is a char array.
-/// ctx->log(RC_LOG_ERROR, "buildTiledNavigation: Could not load '%s'", filepath);
-/// @endcode
 void rcContext::log(const rcLogCategory category, const char* format, ...)
 {
 	if (!m_logEnabled)
+	{
 		return;
+	}
 	static const int MSG_SIZE = 512;
 	char msg[MSG_SIZE];
-	va_list ap;
-	va_start(ap, format);
-	int len = vsnprintf(msg, MSG_SIZE, format, ap);
+	va_list argList;
+	va_start(argList, format);
+	int len = vsnprintf(msg, MSG_SIZE, format, argList);
 	if (len >= MSG_SIZE)
 	{
-		len = MSG_SIZE-1;
-		msg[MSG_SIZE-1] = '\0';
+		len = MSG_SIZE - 1;
+		msg[MSG_SIZE - 1] = '\0';
+
+		const char* errorMessage = "Log message was truncated";
+		doLog(rcLogCategory::RC_LOG_ERROR, errorMessage, (int)strlen(errorMessage));
 	}
-	va_end(ap);
+	va_end(argList);
 	doLog(category, msg, len);
 }
 
@@ -103,6 +89,7 @@ rcHeightfield* rcAllocHeightfield()
 {
 	return rcNew<rcHeightfield>(RC_ALLOC_PERM);
 }
+
 rcHeightfield::rcHeightfield()
 	: width()
 	, height()
@@ -145,24 +132,32 @@ void rcFreeCompactHeightfield(rcCompactHeightfield* chf)
 }
 
 rcCompactHeightfield::rcCompactHeightfield()
-	: width(),
-	height(),
-	spanCount(),
-	walkableHeight(),
-	walkableClimb(),
-	borderSize(),
-	maxDistance(),
-	maxRegions(),
-	bmin(),
-	bmax(),
-	cs(),
-	ch(),
-	cells(),
-	spans(),
-	dist(),
-	areas()
+: width(0)
+, height(0)
+, spanCount(0)
+, walkableHeight(0)
+, walkableClimb(0)
+, borderSize(0)
+, maxDistance(0)
+, maxRegions(0)
+, bmin()
+, bmax()
+, cs(0)
+, ch(0)
+, cells(NULL)
+, spans(NULL)
+, dist(NULL)
+, areas(NULL)
 {
+	bmin[0] = 0;
+	bmin[1] = 0;
+	bmin[2] = 0;
+
+	bmax[0] = 0;
+	bmax[1] = 0;
+	bmax[2] = 0;
 }
+
 rcCompactHeightfield::~rcCompactHeightfield()
 {
 	rcFree(cells);
@@ -175,13 +170,17 @@ rcHeightfieldLayerSet* rcAllocHeightfieldLayerSet()
 {
 	return rcNew<rcHeightfieldLayerSet>(RC_ALLOC_PERM);
 }
+
 void rcFreeHeightfieldLayerSet(rcHeightfieldLayerSet* lset)
 {
 	rcDelete(lset);
 }
 
 rcHeightfieldLayerSet::rcHeightfieldLayerSet()
-	: layers(),	nlayers() {}
+	: layers(), nlayers()
+{
+}
+
 rcHeightfieldLayerSet::~rcHeightfieldLayerSet()
 {
 	for (int i = 0; i < nlayers; ++i)
@@ -198,6 +197,7 @@ rcContourSet* rcAllocContourSet()
 {
 	return rcNew<rcContourSet>(RC_ALLOC_PERM);
 }
+
 void rcFreeContourSet(rcContourSet* cset)
 {
 	rcDelete(cset);
@@ -224,11 +224,11 @@ rcContourSet::~rcContourSet()
 	rcFree(conts);
 }
 
-
 rcPolyMesh* rcAllocPolyMesh()
 {
 	return rcNew<rcPolyMesh>(RC_ALLOC_PERM);
 }
+
 void rcFreePolyMesh(rcPolyMesh* pmesh)
 {
 	rcDelete(pmesh);
@@ -283,7 +283,7 @@ void rcCalcBounds(const float* verts, int nv, float* bmin, float* bmax)
 	rcVcopy(bmax, verts);
 	for (int i = 1; i < nv; ++i)
 	{
-		const float* v = &verts[i*3];
+		const float* v = &verts[i * 3];
 		rcVmin(bmin, v);
 		rcVmax(bmax, v);
 	}
@@ -291,31 +291,28 @@ void rcCalcBounds(const float* verts, int nv, float* bmin, float* bmax)
 
 void rcCalcGridSize(const float* bmin, const float* bmax, float cs, int* w, int* h)
 {
-	*w = (int)((bmax[0] - bmin[0])/cs+0.5f);
-	*h = (int)((bmax[2] - bmin[2])/cs+0.5f);
+	*w = (int)((bmax[0] - bmin[0]) / cs + 0.5f);
+	*h = (int)((bmax[2] - bmin[2]) / cs + 0.5f);
 }
 
-/// @par
-///
-/// See the #rcConfig documentation for more information on the configuration parameters.
-/// 
-/// @see rcAllocHeightfield, rcHeightfield 
 bool rcCreateHeightfield(rcContext* ctx, rcHeightfield& hf, int width, int height,
-						 const float* bmin, const float* bmax,
-						 float cs, float ch)
+                         const float* bmin, const float* bmax,
+                         float cs, float ch)
 {
 	rcIgnoreUnused(ctx);
-	
+
 	hf.width = width;
 	hf.height = height;
 	rcVcopy(hf.bmin, bmin);
 	rcVcopy(hf.bmax, bmax);
 	hf.cs = cs;
 	hf.ch = ch;
-	hf.spans = (rcSpan**)rcAlloc(sizeof(rcSpan*)*hf.width*hf.height, RC_ALLOC_PERM);
+	hf.spans = (rcSpan**)rcAlloc(sizeof(rcSpan*) * hf.width * hf.height, RC_ALLOC_PERM);
 	if (!hf.spans)
+	{
 		return false;
-	memset(hf.spans, 0, sizeof(rcSpan*)*hf.width*hf.height);
+	}
+	memset(hf.spans, 0, sizeof(rcSpan*) * hf.width * hf.height);
 	return true;
 }
 
@@ -328,69 +325,58 @@ static void calcTriNormal(const float* v0, const float* v1, const float* v2, flo
 	rcVnormalize(norm);
 }
 
-/// @par
-///
-/// Only sets the area id's for the walkable triangles.  Does not alter the
-/// area id's for unwalkable triangles.
-/// 
-/// See the #rcConfig documentation for more information on the configuration parameters.
-/// 
-/// @see rcHeightfield, rcClearUnwalkableTriangles, rcRasterizeTriangles
 void rcMarkWalkableTriangles(rcContext* ctx, const float walkableSlopeAngle,
-							 const float* verts, int nv,
-							 const int* tris, int nt,
-							 unsigned char* areas)
+                             const float* verts, int nv,
+                             const int* tris, int nt,
+                             unsigned char* areas)
 {
 	rcIgnoreUnused(ctx);
 	rcIgnoreUnused(nv);
-	
-	const float walkableThr = cosf(walkableSlopeAngle/180.0f*RC_PI);
+
+	const float walkableThr = cosf(walkableSlopeAngle / 180.0f * RC_PI);
 
 	float norm[3];
-	
+
 	for (int i = 0; i < nt; ++i)
 	{
-		const int* tri = &tris[i*3];
-		calcTriNormal(&verts[tri[0]*3], &verts[tri[1]*3], &verts[tri[2]*3], norm);
+		const int* tri = &tris[i * 3];
+		calcTriNormal(&verts[tri[0] * 3], &verts[tri[1] * 3], &verts[tri[2] * 3], norm);
 		// Check if the face is walkable.
 		if (norm[1] > walkableThr)
+		{
 			areas[i] = RC_WALKABLE_AREA;
+		}
 	}
 }
 
-/// @par
-///
-/// Only sets the area id's for the unwalkable triangles.  Does not alter the
-/// area id's for walkable triangles.
-/// 
-/// See the #rcConfig documentation for more information on the configuration parameters.
-/// 
-/// @see rcHeightfield, rcClearUnwalkableTriangles, rcRasterizeTriangles
 void rcClearUnwalkableTriangles(rcContext* ctx, const float walkableSlopeAngle,
-								const float* verts, int /*nv*/,
-								const int* tris, int nt,
-								unsigned char* areas)
+                                const float* verts, int nv,
+                                const int* tris, int nt,
+                                unsigned char* areas)
 {
 	rcIgnoreUnused(ctx);
-	
-	const float walkableThr = cosf(walkableSlopeAngle/180.0f*RC_PI);
-	
+	rcIgnoreUnused(nv);
+
+	const float walkableThr = cosf(walkableSlopeAngle / 180.0f * RC_PI);
+
 	float norm[3];
-	
+
 	for (int i = 0; i < nt; ++i)
 	{
-		const int* tri = &tris[i*3];
-		calcTriNormal(&verts[tri[0]*3], &verts[tri[1]*3], &verts[tri[2]*3], norm);
+		const int* tri = &tris[i * 3];
+		calcTriNormal(&verts[tri[0] * 3], &verts[tri[1] * 3], &verts[tri[2] * 3], norm);
 		// Check if the face is walkable.
 		if (norm[1] <= walkableThr)
+		{
 			areas[i] = RC_NULL_AREA;
+		}
 	}
 }
 
 int rcGetHeightFieldSpanCount(rcContext* ctx, rcHeightfield& hf)
 {
 	rcIgnoreUnused(ctx);
-	
+
 	const int w = hf.width;
 	const int h = hf.height;
 	int spanCount = 0;
@@ -398,7 +384,7 @@ int rcGetHeightFieldSpanCount(rcContext* ctx, rcHeightfield& hf)
 	{
 		for (int x = 0; x < w; ++x)
 		{
-			for (rcSpan* s = hf.spans[x + y*w]; s; s = s->next)
+			for (rcSpan* s = hf.spans[x + y * w]; s; s = s->next)
 			{
 				if (s->area != RC_NULL_AREA)
 					spanCount++;
@@ -408,22 +394,13 @@ int rcGetHeightFieldSpanCount(rcContext* ctx, rcHeightfield& hf)
 	return spanCount;
 }
 
-/// @par
-///
-/// This is just the beginning of the process of fully building a compact heightfield.
-/// Various filters may be applied, then the distance field and regions built.
-/// E.g: #rcBuildDistanceField and #rcBuildRegions
-///
-/// See the #rcConfig documentation for more information on the configuration parameters.
-///
-/// @see rcAllocCompactHeightfield, rcHeightfield, rcCompactHeightfield, rcConfig
 bool rcBuildCompactHeightfield(rcContext* ctx, const int walkableHeight, const int walkableClimb,
-							   rcHeightfield& hf, rcCompactHeightfield& chf)
+                               rcHeightfield& hf, rcCompactHeightfield& chf)
 {
 	rcAssert(ctx);
-	
+
 	rcScopedTimer timer(ctx, RC_TIMER_BUILD_COMPACTHEIGHTFIELD);
-	
+
 	const int w = hf.width;
 	const int h = hf.height;
 	const int spanCount = rcGetHeightFieldSpanCount(ctx, hf);
@@ -437,43 +414,43 @@ bool rcBuildCompactHeightfield(rcContext* ctx, const int walkableHeight, const i
 	chf.maxRegions = 0;
 	rcVcopy(chf.bmin, hf.bmin);
 	rcVcopy(chf.bmax, hf.bmax);
-	chf.bmax[1] += walkableHeight*hf.ch;
+	chf.bmax[1] += walkableHeight * hf.ch;
 	chf.cs = hf.cs;
 	chf.ch = hf.ch;
-	chf.cells = (rcCompactCell*)rcAlloc(sizeof(rcCompactCell)*w*h, RC_ALLOC_PERM);
+	chf.cells = (rcCompactCell*)rcAlloc(sizeof(rcCompactCell) * w * h, RC_ALLOC_PERM);
 	if (!chf.cells)
 	{
-		ctx->log(RC_LOG_ERROR, "rcBuildCompactHeightfield: Out of memory 'chf.cells' (%d)", w*h);
+		ctx->log(RC_LOG_ERROR, "rcBuildCompactHeightfield: Out of memory 'chf.cells' (%d)", w * h);
 		return false;
 	}
-	memset(chf.cells, 0, sizeof(rcCompactCell)*w*h);
-	chf.spans = (rcCompactSpan*)rcAlloc(sizeof(rcCompactSpan)*spanCount, RC_ALLOC_PERM);
+	memset(chf.cells, 0, sizeof(rcCompactCell) * w * h);
+	chf.spans = (rcCompactSpan*)rcAlloc(sizeof(rcCompactSpan) * spanCount, RC_ALLOC_PERM);
 	if (!chf.spans)
 	{
 		ctx->log(RC_LOG_ERROR, "rcBuildCompactHeightfield: Out of memory 'chf.spans' (%d)", spanCount);
 		return false;
 	}
-	memset(chf.spans, 0, sizeof(rcCompactSpan)*spanCount);
-	chf.areas = (unsigned char*)rcAlloc(sizeof(unsigned char)*spanCount, RC_ALLOC_PERM);
+	memset(chf.spans, 0, sizeof(rcCompactSpan) * spanCount);
+	chf.areas = (unsigned char*)rcAlloc(sizeof(unsigned char) * spanCount, RC_ALLOC_PERM);
 	if (!chf.areas)
 	{
 		ctx->log(RC_LOG_ERROR, "rcBuildCompactHeightfield: Out of memory 'chf.areas' (%d)", spanCount);
 		return false;
 	}
-	memset(chf.areas, RC_NULL_AREA, sizeof(unsigned char)*spanCount);
-	
+	memset(chf.areas, RC_NULL_AREA, sizeof(unsigned char) * spanCount);
+
 	const int MAX_HEIGHT = 0xffff;
-	
+
 	// Fill in cells and spans.
 	int idx = 0;
 	for (int y = 0; y < h; ++y)
 	{
 		for (int x = 0; x < w; ++x)
 		{
-			const rcSpan* s = hf.spans[x + y*w];
+			const rcSpan* s = hf.spans[x + y * w];
 			// If there are no spans at this cell, just leave the data to index=0, count=0.
 			if (!s) continue;
-			rcCompactCell& c = chf.cells[x+y*w];
+			rcCompactCell& c = chf.cells[x + y * w];
 			c.index = idx;
 			c.count = 0;
 			while (s)
@@ -494,17 +471,17 @@ bool rcBuildCompactHeightfield(rcContext* ctx, const int walkableHeight, const i
 	}
 
 	// Find neighbour connections.
-	const int MAX_LAYERS = RC_NOT_CONNECTED-1;
+	const int MAX_LAYERS = RC_NOT_CONNECTED - 1;
 	int tooHighNeighbour = 0;
 	for (int y = 0; y < h; ++y)
 	{
 		for (int x = 0; x < w; ++x)
 		{
-			const rcCompactCell& c = chf.cells[x+y*w];
-			for (int i = (int)c.index, ni = (int)(c.index+c.count); i < ni; ++i)
+			const rcCompactCell& c = chf.cells[x + y * w];
+			for (int i = (int)c.index, ni = (int)(c.index + c.count); i < ni; ++i)
 			{
 				rcCompactSpan& s = chf.spans[i];
-				
+
 				for (int dir = 0; dir < 4; ++dir)
 				{
 					rcSetCon(s, dir, RC_NOT_CONNECTED);
@@ -513,15 +490,15 @@ bool rcBuildCompactHeightfield(rcContext* ctx, const int walkableHeight, const i
 					// First check that the neighbour cell is in bounds.
 					if (nx < 0 || ny < 0 || nx >= w || ny >= h)
 						continue;
-						
+
 					// Iterate over all neighbour spans and check if any of the is
 					// accessible from current cell.
-					const rcCompactCell& nc = chf.cells[nx+ny*w];
-					for (int k = (int)nc.index, nk = (int)(nc.index+nc.count); k < nk; ++k)
+					const rcCompactCell& nc = chf.cells[nx + ny * w];
+					for (int k = (int)nc.index, nk = (int)(nc.index + nc.count); k < nk; ++k)
 					{
 						const rcCompactSpan& ns = chf.spans[k];
 						const int bot = rcMax(s.y, ns.y);
-						const int top = rcMin(s.y+s.h, ns.y+ns.h);
+						const int top = rcMin(s.y + s.h, ns.y + ns.h);
 
 						// Check that the gap between the spans is walkable,
 						// and that the climb height between the gaps is not too high.
@@ -538,43 +515,16 @@ bool rcBuildCompactHeightfield(rcContext* ctx, const int walkableHeight, const i
 							break;
 						}
 					}
-					
 				}
 			}
 		}
 	}
-	
+
 	if (tooHighNeighbour > MAX_LAYERS)
 	{
 		ctx->log(RC_LOG_ERROR, "rcBuildCompactHeightfield: Heightfield has too many layers %d (max: %d)",
-				 tooHighNeighbour, MAX_LAYERS);
+		         tooHighNeighbour, MAX_LAYERS);
 	}
-	
+
 	return true;
 }
-
-/*
-static int getHeightfieldMemoryUsage(const rcHeightfield& hf)
-{
-	int size = 0;
-	size += sizeof(hf);
-	size += hf.width * hf.height * sizeof(rcSpan*);
-	
-	rcSpanPool* pool = hf.pools;
-	while (pool)
-	{
-		size += (sizeof(rcSpanPool) - sizeof(rcSpan)) + sizeof(rcSpan)*RC_SPANS_PER_POOL;
-		pool = pool->next;
-	}
-	return size;
-}
-
-static int getCompactHeightFieldMemoryusage(const rcCompactHeightfield& chf)
-{
-	int size = 0;
-	size += sizeof(rcCompactHeightfield);
-	size += sizeof(rcCompactSpan) * chf.spanCount;
-	size += sizeof(rcCompactCell) * chf.width * chf.height;
-	return size;
-}
-*/

--- a/Recast/Source/Recast.cpp
+++ b/Recast/Source/Recast.cpp
@@ -91,16 +91,23 @@ rcHeightfield* rcAllocHeightfield()
 }
 
 rcHeightfield::rcHeightfield()
-	: width()
-	, height()
-	, bmin()
-	, bmax()
-	, cs()
-	, ch()
-	, spans()
-	, pools()
-	, freelist()
+: width(0)
+, height(0)
+, bmin()
+, bmax()
+, cs(0)
+, ch(0)
+, spans(NULL)
+, pools(NULL)
+, freelist(NULL)
 {
+	bmin[0] = 0;
+	bmin[1] = 0;
+	bmin[2] = 0;
+
+	bmax[0] = 0;
+	bmax[1] = 0;
+	bmax[2] = 0;
 }
 
 rcHeightfield::~rcHeightfield()
@@ -177,7 +184,8 @@ void rcFreeHeightfieldLayerSet(rcHeightfieldLayerSet* lset)
 }
 
 rcHeightfieldLayerSet::rcHeightfieldLayerSet()
-	: layers(), nlayers()
+: layers(NULL)
+, nlayers(0)
 {
 }
 
@@ -204,16 +212,26 @@ void rcFreeContourSet(rcContourSet* cset)
 }
 
 rcContourSet::rcContourSet()
-	: conts(),
-	nconts(),
-	bmin(),
-	bmax(),
-	cs(),
-	ch(),
-	width(),
-	height(),
-	borderSize(),
-	maxError() {}
+: conts(0)
+, nconts(0)
+, bmin()
+, bmax()
+, cs(0)
+, ch(0)
+, width(0)
+, height(0)
+, borderSize(0)
+, maxError(0)
+{
+	bmin[0] = 0;
+	bmin[1] = 0;
+	bmin[2] = 0;
+
+	bmax[0] = 0;
+	bmax[1] = 0;
+	bmax[2] = 0;
+}
+
 rcContourSet::~rcContourSet()
 {
 	for (int i = 0; i < nconts; ++i)
@@ -235,21 +253,30 @@ void rcFreePolyMesh(rcPolyMesh* pmesh)
 }
 
 rcPolyMesh::rcPolyMesh()
-	: verts(),
-	polys(),
-	regs(),
-	flags(),
-	areas(),
-	nverts(),
-	npolys(),
-	maxpolys(),
-	nvp(),
-	bmin(),
-	bmax(),
-	cs(),
-	ch(),
-	borderSize(),
-	maxEdgeError() {}
+: verts(NULL)
+, polys(NULL)
+, regs(NULL)
+, flags(NULL)
+, areas(NULL)
+, nverts(0)
+, npolys(0)
+, maxpolys(0)
+, nvp(0)
+, bmin()
+, bmax()
+, cs(0)
+, ch(0)
+, borderSize(0)
+, maxEdgeError(0)
+{
+	bmin[0] = 0;
+	bmin[1] = 0;
+	bmin[2] = 0;
+
+	bmax[0] = 0;
+	bmax[1] = 0;
+	bmax[2] = 0;
+}
 
 rcPolyMesh::~rcPolyMesh()
 {

--- a/Recast/Source/Recast.cpp
+++ b/Recast/Source/Recast.cpp
@@ -95,23 +95,16 @@ void rcFreeHeightField(rcHeightfield* heightfield)
 }
 
 rcHeightfield::rcHeightfield()
-: width(0)
-, height(0)
+: width()
+, height()
 , bmin()
 , bmax()
-, cs(0)
-, ch(0)
-, spans(NULL)
-, pools(NULL)
-, freelist(NULL)
+, cs()
+, ch()
+, spans()
+, pools()
+, freelist()
 {
-	bmin[0] = 0;
-	bmin[1] = 0;
-	bmin[2] = 0;
-
-	bmax[0] = 0;
-	bmax[1] = 0;
-	bmax[2] = 0;
 }
 
 rcHeightfield::~rcHeightfield()
@@ -138,30 +131,23 @@ void rcFreeCompactHeightfield(rcCompactHeightfield* compactHeightfield)
 }
 
 rcCompactHeightfield::rcCompactHeightfield()
-: width(0)
-, height(0)
-, spanCount(0)
-, walkableHeight(0)
-, walkableClimb(0)
-, borderSize(0)
-, maxDistance(0)
-, maxRegions(0)
+: width()
+, height()
+, spanCount()
+, walkableHeight()
+, walkableClimb()
+, borderSize()
+, maxDistance()
+, maxRegions()
 , bmin()
 , bmax()
-, cs(0)
-, ch(0)
-, cells(NULL)
-, spans(NULL)
-, dist(NULL)
-, areas(NULL)
+, cs()
+, ch()
+, cells()
+, spans()
+, dist()
+, areas()
 {
-	bmin[0] = 0;
-	bmin[1] = 0;
-	bmin[2] = 0;
-
-	bmax[0] = 0;
-	bmax[1] = 0;
-	bmax[2] = 0;
 }
 
 rcCompactHeightfield::~rcCompactHeightfield()
@@ -183,8 +169,8 @@ void rcFreeHeightfieldLayerSet(rcHeightfieldLayerSet* layerSet)
 }
 
 rcHeightfieldLayerSet::rcHeightfieldLayerSet()
-: layers(NULL)
-, nlayers(0)
+: layers()
+, nlayers()
 {
 }
 
@@ -211,24 +197,17 @@ void rcFreeContourSet(rcContourSet* contourSet)
 }
 
 rcContourSet::rcContourSet()
-: conts(0)
-, nconts(0)
+: conts()
+, nconts()
 , bmin()
 , bmax()
-, cs(0)
-, ch(0)
-, width(0)
-, height(0)
-, borderSize(0)
-, maxError(0)
+, cs()
+, ch()
+, width()
+, height()
+, borderSize()
+, maxError()
 {
-	bmin[0] = 0;
-	bmin[1] = 0;
-	bmin[2] = 0;
-
-	bmax[0] = 0;
-	bmax[1] = 0;
-	bmax[2] = 0;
 }
 
 rcContourSet::~rcContourSet()
@@ -252,29 +231,22 @@ void rcFreePolyMesh(rcPolyMesh* polyMesh)
 }
 
 rcPolyMesh::rcPolyMesh()
-: verts(NULL)
-, polys(NULL)
-, regs(NULL)
-, flags(NULL)
-, areas(NULL)
-, nverts(0)
-, npolys(0)
-, maxpolys(0)
-, nvp(0)
+: verts()
+, polys()
+, regs()
+, flags()
+, areas()
+, nverts()
+, npolys()
+, maxpolys()
+, nvp()
 , bmin()
 , bmax()
-, cs(0)
-, ch(0)
-, borderSize(0)
-, maxEdgeError(0)
+, cs()
+, ch()
+, borderSize()
+, maxEdgeError()
 {
-	bmin[0] = 0;
-	bmin[1] = 0;
-	bmin[2] = 0;
-
-	bmax[0] = 0;
-	bmax[1] = 0;
-	bmax[2] = 0;
 }
 
 rcPolyMesh::~rcPolyMesh()
@@ -297,12 +269,12 @@ void rcFreePolyMeshDetail(rcPolyMeshDetail* detailMesh)
 }
 
 rcPolyMeshDetail::rcPolyMeshDetail()
-: meshes(NULL)
-, verts(NULL)
-, tris(NULL)
-, nmeshes(0)
-, nverts(0)
-, ntris(0)
+: meshes()
+, verts()
+, tris()
+, nmeshes()
+, nverts()
+, ntris()
 {
 }
 

--- a/Recast/Source/Recast.cpp
+++ b/Recast/Source/Recast.cpp
@@ -288,18 +288,29 @@ rcPolyMesh::~rcPolyMesh()
 
 rcPolyMeshDetail* rcAllocPolyMeshDetail()
 {
-	rcPolyMeshDetail* dmesh = (rcPolyMeshDetail*)rcAlloc(sizeof(rcPolyMeshDetail), RC_ALLOC_PERM);
-	memset(dmesh, 0, sizeof(rcPolyMeshDetail));
-	return dmesh;
+	return rcNew<rcPolyMeshDetail>(RC_ALLOC_PERM);
 }
 
-void rcFreePolyMeshDetail(rcPolyMeshDetail* dmesh)
+void rcFreePolyMeshDetail(rcPolyMeshDetail* detailMesh)
 {
-	if (!dmesh) return;
-	rcFree(dmesh->meshes);
-	rcFree(dmesh->verts);
-	rcFree(dmesh->tris);
-	rcFree(dmesh);
+	rcDelete(detailMesh);
+}
+
+rcPolyMeshDetail::rcPolyMeshDetail()
+: meshes(NULL)
+, verts(NULL)
+, tris(NULL)
+, nmeshes(0)
+, nverts(0)
+, ntris(0)
+{
+}
+
+rcPolyMeshDetail::~rcPolyMeshDetail()
+{
+	rcFree(meshes);
+	rcFree(verts);
+	rcFree(tris);
 }
 
 void rcCalcBounds(const float* verts, int numVerts, float* minBounds, float* maxBounds)

--- a/Recast/Source/RecastAlloc.cpp
+++ b/Recast/Source/RecastAlloc.cpp
@@ -18,8 +18,6 @@
 
 #include "RecastAlloc.h"
 
-#include <stdlib.h>
-
 static void* rcAllocDefault(size_t size, rcAllocHint)
 {
 	return malloc(size);

--- a/Recast/Source/RecastAlloc.cpp
+++ b/Recast/Source/RecastAlloc.cpp
@@ -16,12 +16,11 @@
 // 3. This notice may not be removed or altered from any source distribution.
 //
 
-#include <stdlib.h>
-#include <string.h>
 #include "RecastAlloc.h"
-#include "RecastAssert.h"
 
-static void *rcAllocDefault(size_t size, rcAllocHint)
+#include <stdlib.h>
+
+static void* rcAllocDefault(size_t size, rcAllocHint)
 {
 	return malloc(size);
 }
@@ -34,27 +33,21 @@ static void rcFreeDefault(void *ptr)
 static rcAllocFunc* sRecastAllocFunc = rcAllocDefault;
 static rcFreeFunc* sRecastFreeFunc = rcFreeDefault;
 
-/// @see rcAlloc, rcFree
-void rcAllocSetCustom(rcAllocFunc *allocFunc, rcFreeFunc *freeFunc)
+void rcAllocSetCustom(rcAllocFunc* allocFunc, rcFreeFunc* freeFunc)
 {
 	sRecastAllocFunc = allocFunc ? allocFunc : rcAllocDefault;
 	sRecastFreeFunc = freeFunc ? freeFunc : rcFreeDefault;
 }
 
-/// @see rcAllocSetCustom
 void* rcAlloc(size_t size, rcAllocHint hint)
 {
 	return sRecastAllocFunc(size, hint);
 }
 
-/// @par
-///
-/// @warning This function leaves the value of @p ptr unchanged.  So it still
-/// points to the same (now invalid) location, and not to null.
-/// 
-/// @see rcAllocSetCustom
 void rcFree(void* ptr)
 {
 	if (ptr)
+	{
 		sRecastFreeFunc(ptr);
+	}
 }

--- a/Recast/Source/RecastAlloc.cpp
+++ b/Recast/Source/RecastAlloc.cpp
@@ -46,7 +46,7 @@ void* rcAlloc(size_t size, rcAllocHint hint)
 
 void rcFree(void* ptr)
 {
-	if (ptr)
+	if (ptr != NULL)
 	{
 		sRecastFreeFunc(ptr);
 	}

--- a/Recast/Source/RecastAssert.cpp
+++ b/Recast/Source/RecastAssert.cpp
@@ -22,7 +22,7 @@
 
 static rcAssertFailFunc* sRecastAssertFailFunc = 0;
 
-void rcAssertFailSetCustom(rcAssertFailFunc *assertFailFunc)
+void rcAssertFailSetCustom(rcAssertFailFunc* assertFailFunc)
 {
 	sRecastAssertFailFunc = assertFailFunc;
 }

--- a/Recast/Source/RecastFilter.cpp
+++ b/Recast/Source/RecastFilter.cpp
@@ -19,6 +19,8 @@
 #include "Recast.h"
 #include "RecastAssert.h"
 
+#include <stdlib.h>
+
 void rcFilterLowHangingWalkableObstacles(rcContext* context, const int walkableClimb, rcHeightfield& heightfield)
 {
 	rcAssert(context);

--- a/Recast/Source/RecastFilter.cpp
+++ b/Recast/Source/RecastFilter.cpp
@@ -16,186 +16,166 @@
 // 3. This notice may not be removed or altered from any source distribution.
 //
 
-#define _USE_MATH_DEFINES
-#include <math.h>
-#include <stdio.h>
 #include "Recast.h"
 #include "RecastAssert.h"
 
-/// @par
-///
-/// Allows the formation of walkable regions that will flow over low lying 
-/// objects such as curbs, and up structures such as stairways. 
-/// 
-/// Two neighboring spans are walkable if: <tt>rcAbs(currentSpan.smax - neighborSpan.smax) < waklableClimb</tt>
-/// 
-/// @warning Will override the effect of #rcFilterLedgeSpans.  So if both filters are used, call
-/// #rcFilterLedgeSpans after calling this filter. 
-///
-/// @see rcHeightfield, rcConfig
-void rcFilterLowHangingWalkableObstacles(rcContext* ctx, const int walkableClimb, rcHeightfield& solid)
+void rcFilterLowHangingWalkableObstacles(rcContext* context, const int walkableClimb, rcHeightfield& heightfield)
 {
-	rcAssert(ctx);
+	rcAssert(context);
 
-	rcScopedTimer timer(ctx, RC_TIMER_FILTER_LOW_OBSTACLES);
-	
-	const int w = solid.width;
-	const int h = solid.height;
-	
-	for (int y = 0; y < h; ++y)
+	rcScopedTimer timer(context, RC_TIMER_FILTER_LOW_OBSTACLES);
+
+	const int xSize = heightfield.width;
+	const int zSize = heightfield.height;
+
+	for (int z = 0; z < zSize; ++z)
 	{
-		for (int x = 0; x < w; ++x)
+		for (int x = 0; x < xSize; ++x)
 		{
-			rcSpan* ps = 0;
-			bool previousWalkable = false;
+			rcSpan* previousSpan = NULL;
+			bool previousWasWalkable = false;
 			unsigned char previousArea = RC_NULL_AREA;
-			
-			for (rcSpan* s = solid.spans[x + y*w]; s; ps = s, s = s->next)
+
+			for (rcSpan* span = heightfield.spans[x + z * xSize]; span != NULL; previousSpan = span, span = span->next)
 			{
-				const bool walkable = s->area != RC_NULL_AREA;
+				const bool walkable = span->area != RC_NULL_AREA;
 				// If current span is not walkable, but there is walkable
 				// span just below it, mark the span above it walkable too.
-				if (!walkable && previousWalkable)
+				if (!walkable && previousWasWalkable)
 				{
-					if (rcAbs((int)s->smax - (int)ps->smax) <= walkableClimb)
-						s->area = previousArea;
+					if (rcAbs((int)span->smax - (int)previousSpan->smax) <= walkableClimb)
+					{
+						span->area = previousArea;
+					}
 				}
 				// Copy walkable flag so that it cannot propagate
 				// past multiple non-walkable objects.
-				previousWalkable = walkable;
-				previousArea = s->area;
+				previousWasWalkable = walkable;
+				previousArea = span->area;
 			}
 		}
 	}
 }
 
-/// @par
-///
-/// A ledge is a span with one or more neighbors whose maximum is further away than @p walkableClimb
-/// from the current span's maximum.
-/// This method removes the impact of the overestimation of conservative voxelization 
-/// so the resulting mesh will not have regions hanging in the air over ledges.
-/// 
-/// A span is a ledge if: <tt>rcAbs(currentSpan.smax - neighborSpan.smax) > walkableClimb</tt>
-/// 
-/// @see rcHeightfield, rcConfig
-void rcFilterLedgeSpans(rcContext* ctx, const int walkableHeight, const int walkableClimb,
-						rcHeightfield& solid)
+void rcFilterLedgeSpans(rcContext* context, const int walkableHeight, const int walkableClimb,
+                        rcHeightfield& heightfield)
 {
-	rcAssert(ctx);
+	rcAssert(context);
 	
-	rcScopedTimer timer(ctx, RC_TIMER_FILTER_BORDER);
+	rcScopedTimer timer(context, RC_TIMER_FILTER_BORDER);
 
-	const int w = solid.width;
-	const int h = solid.height;
-	const int MAX_HEIGHT = 0xffff;
+	const int xSize = heightfield.width;
+	const int zSize = heightfield.height;
+	const int MAX_HEIGHT = 0xffff; // TODO (graham): Move this to a more visible constant and update usages.
 	
 	// Mark border spans.
-	for (int y = 0; y < h; ++y)
+	for (int z = 0; z < zSize; ++z)
 	{
-		for (int x = 0; x < w; ++x)
+		for (int x = 0; x < xSize; ++x)
 		{
-			for (rcSpan* s = solid.spans[x + y*w]; s; s = s->next)
+			for (rcSpan* span = heightfield.spans[x + z * xSize]; span; span = span->next)
 			{
 				// Skip non walkable spans.
-				if (s->area == RC_NULL_AREA)
+				if (span->area == RC_NULL_AREA)
+				{
 					continue;
-				
-				const int bot = (int)(s->smax);
-				const int top = s->next ? (int)(s->next->smin) : MAX_HEIGHT;
-				
+				}
+
+				const int bot = (int)(span->smax);
+				const int top = span->next ? (int)(span->next->smin) : MAX_HEIGHT;
+
 				// Find neighbours minimum height.
-				int minh = MAX_HEIGHT;
+				int minNeighborHeight = MAX_HEIGHT;
 
 				// Min and max height of accessible neighbours.
-				int asmin = s->smax;
-				int asmax = s->smax;
+				int accessibleNeighborMinHeight = span->smax;
+				int accessibleNeighborMaxHeight = span->smax;
 
-				for (int dir = 0; dir < 4; ++dir)
+				for (int direction = 0; direction < 4; ++direction)
 				{
-					int dx = x + rcGetDirOffsetX(dir);
-					int dy = y + rcGetDirOffsetY(dir);
+					int dx = x + rcGetDirOffsetX(direction);
+					int dy = z + rcGetDirOffsetY(direction);
 					// Skip neighbours which are out of bounds.
-					if (dx < 0 || dy < 0 || dx >= w || dy >= h)
+					if (dx < 0 || dy < 0 || dx >= xSize || dy >= zSize)
 					{
-						minh = rcMin(minh, -walkableClimb - bot);
+						minNeighborHeight = rcMin(minNeighborHeight, -walkableClimb - bot);
 						continue;
 					}
 
 					// From minus infinity to the first span.
-					rcSpan* ns = solid.spans[dx + dy*w];
-					int nbot = -walkableClimb;
-					int ntop = ns ? (int)ns->smin : MAX_HEIGHT;
-					// Skip neightbour if the gap between the spans is too small.
-					if (rcMin(top,ntop) - rcMax(bot,nbot) > walkableHeight)
-						minh = rcMin(minh, nbot - bot);
+					const rcSpan* neighborSpan = heightfield.spans[dx + dy * xSize];
+					int neighborBot = -walkableClimb;
+					int neighborTop = neighborSpan ? (int)neighborSpan->smin : MAX_HEIGHT;
 					
-					// Rest of the spans.
-					for (ns = solid.spans[dx + dy*w]; ns; ns = ns->next)
+					// Skip neighbour if the gap between the spans is too small.
+					if (rcMin(top, neighborTop) - rcMax(bot, neighborBot) > walkableHeight)
 					{
-						nbot = (int)ns->smax;
-						ntop = ns->next ? (int)ns->next->smin : MAX_HEIGHT;
-						// Skip neightbour if the gap between the spans is too small.
-						if (rcMin(top,ntop) - rcMax(bot,nbot) > walkableHeight)
-						{
-							minh = rcMin(minh, nbot - bot);
+						minNeighborHeight = rcMin(minNeighborHeight, neighborBot - bot);
+					}
+
+					// Rest of the spans.
+					for (neighborSpan = heightfield.spans[dx + dy * xSize]; neighborSpan; neighborSpan = neighborSpan->next)
+					{
+						neighborBot = (int)neighborSpan->smax;
+						neighborTop = neighborSpan->next ? (int)neighborSpan->next->smin : MAX_HEIGHT;
 						
+						// Skip neighbour if the gap between the spans is too small.
+						if (rcMin(top, neighborTop) - rcMax(bot, neighborBot) > walkableHeight)
+						{
+							minNeighborHeight = rcMin(minNeighborHeight, neighborBot - bot);
+
 							// Find min/max accessible neighbour height. 
-							if (rcAbs(nbot - bot) <= walkableClimb)
+							if (rcAbs(neighborBot - bot) <= walkableClimb)
 							{
-								if (nbot < asmin) asmin = nbot;
-								if (nbot > asmax) asmax = nbot;
+								if (neighborBot < accessibleNeighborMinHeight) accessibleNeighborMinHeight = neighborBot;
+								if (neighborBot > accessibleNeighborMaxHeight) accessibleNeighborMaxHeight = neighborBot;
 							}
-							
+
 						}
 					}
 				}
-				
+
 				// The current span is close to a ledge if the drop to any
 				// neighbour span is less than the walkableClimb.
-				if (minh < -walkableClimb)
+				if (minNeighborHeight < -walkableClimb)
 				{
-					s->area = RC_NULL_AREA;
+					span->area = RC_NULL_AREA;
 				}
 				// If the difference between all neighbours is too large,
 				// we are at steep slope, mark the span as ledge.
-				else if ((asmax - asmin) > walkableClimb)
+				else if ((accessibleNeighborMaxHeight - accessibleNeighborMinHeight) > walkableClimb)
 				{
-					s->area = RC_NULL_AREA;
+					span->area = RC_NULL_AREA;
 				}
 			}
 		}
 	}
 }
 
-/// @par
-///
-/// For this filter, the clearance above the span is the distance from the span's 
-/// maximum to the next higher span's minimum. (Same grid column.)
-/// 
-/// @see rcHeightfield, rcConfig
-void rcFilterWalkableLowHeightSpans(rcContext* ctx, int walkableHeight, rcHeightfield& solid)
+void rcFilterWalkableLowHeightSpans(rcContext* context, const int walkableHeight, rcHeightfield& heightfield)
 {
-	rcAssert(ctx);
+	rcAssert(context);
 	
-	rcScopedTimer timer(ctx, RC_TIMER_FILTER_WALKABLE);
+	rcScopedTimer timer(context, RC_TIMER_FILTER_WALKABLE);
 	
-	const int w = solid.width;
-	const int h = solid.height;
+	const int xSize = heightfield.width;
+	const int zSize = heightfield.height;
 	const int MAX_HEIGHT = 0xffff;
 	
 	// Remove walkable flag from spans which do not have enough
 	// space above them for the agent to stand there.
-	for (int y = 0; y < h; ++y)
+	for (int z = 0; z < zSize; ++z)
 	{
-		for (int x = 0; x < w; ++x)
+		for (int x = 0; x < xSize; ++x)
 		{
-			for (rcSpan* s = solid.spans[x + y*w]; s; s = s->next)
+			for (rcSpan* span = heightfield.spans[x + z*xSize]; span; span = span->next)
 			{
-				const int bot = (int)(s->smax);
-				const int top = s->next ? (int)(s->next->smin) : MAX_HEIGHT;
+				const int bot = (int)(span->smax);
+				const int top = span->next ? (int)(span->next->smin) : MAX_HEIGHT;
 				if ((top - bot) <= walkableHeight)
-					s->area = RC_NULL_AREA;
+				{
+					span->area = RC_NULL_AREA;
+				}
 			}
 		}
 	}

--- a/Recast/Source/RecastRasterization.cpp
+++ b/Recast/Source/RecastRasterization.cpp
@@ -191,13 +191,13 @@ static bool addSpan(rcHeightfield& hf,
 }
 
 bool rcAddSpan(rcContext* context, rcHeightfield& heightfield,
-               const int x, const int y,
+               const int x, const int z,
                const unsigned short spanMin, const unsigned short spanMax,
                const unsigned char areaID, const int flagMergeThreshold)
 {
 	rcAssert(context);
 
-	if (!addSpan(heightfield, x, y, spanMin, spanMax, areaID, flagMergeThreshold))
+	if (!addSpan(heightfield, x, z, spanMin, spanMax, areaID, flagMergeThreshold))
 	{
 		context->log(RC_LOG_ERROR, "rcAddSpan: Out of memory.");
 		return false;
@@ -478,7 +478,7 @@ bool rcRasterizeTriangle(rcContext* context,
 
 bool rcRasterizeTriangles(rcContext* context,
                           const float* verts, const int /*nv*/,
-                          const int* tris, const unsigned char* areaIDs, const int numTris,
+                          const int* tris, const unsigned char* triAreaIDs, const int numTris,
                           rcHeightfield& heightfield, const int flagMergeThreshold)
 {
 	rcAssert(context != NULL);
@@ -493,7 +493,7 @@ bool rcRasterizeTriangles(rcContext* context,
 		const float* v0 = &verts[tris[triIndex * 3 + 0] * 3];
 		const float* v1 = &verts[tris[triIndex * 3 + 1] * 3];
 		const float* v2 = &verts[tris[triIndex * 3 + 2] * 3];
-		if (!rasterizeTri(v0, v1, v2, areaIDs[triIndex], heightfield, heightfield.bmin, heightfield.bmax, heightfield.cs, inverseCellSize, inverseCellHeight, flagMergeThreshold))
+		if (!rasterizeTri(v0, v1, v2, triAreaIDs[triIndex], heightfield, heightfield.bmin, heightfield.bmax, heightfield.cs, inverseCellSize, inverseCellHeight, flagMergeThreshold))
 		{
 			context->log(RC_LOG_ERROR, "rcRasterizeTriangles: Out of memory.");
 			return false;
@@ -505,7 +505,7 @@ bool rcRasterizeTriangles(rcContext* context,
 
 bool rcRasterizeTriangles(rcContext* context,
                           const float* verts, const int /*nv*/,
-                          const unsigned short* tris, const unsigned char* areaIDs, const int numTris,
+                          const unsigned short* tris, const unsigned char* triAreaIDs, const int numTris,
                           rcHeightfield& heightfield, const int flagMergeThreshold)
 {
 	rcAssert(context != NULL);
@@ -520,7 +520,7 @@ bool rcRasterizeTriangles(rcContext* context,
 		const float* v0 = &verts[tris[triIndex * 3 + 0] * 3];
 		const float* v1 = &verts[tris[triIndex * 3 + 1] * 3];
 		const float* v2 = &verts[tris[triIndex * 3 + 2] * 3];
-		if (!rasterizeTri(v0, v1, v2, areaIDs[triIndex], heightfield, heightfield.bmin, heightfield.bmax, heightfield.cs, inverseCellSize, inverseCellHeight, flagMergeThreshold))
+		if (!rasterizeTri(v0, v1, v2, triAreaIDs[triIndex], heightfield, heightfield.bmin, heightfield.bmax, heightfield.cs, inverseCellSize, inverseCellHeight, flagMergeThreshold))
 		{
 			context->log(RC_LOG_ERROR, "rcRasterizeTriangles: Out of memory.");
 			return false;
@@ -531,7 +531,7 @@ bool rcRasterizeTriangles(rcContext* context,
 }
 
 bool rcRasterizeTriangles(rcContext* context,
-                          const float* verts, const unsigned char* areaIDs, const int numTris,
+                          const float* verts, const unsigned char* triAreaIDs, const int numTris,
                           rcHeightfield& heightfield, const int flagMergeThreshold)
 {
 	rcAssert(context != NULL);
@@ -546,7 +546,7 @@ bool rcRasterizeTriangles(rcContext* context,
 		const float* v0 = &verts[(triIndex * 3 + 0) * 3];
 		const float* v1 = &verts[(triIndex * 3 + 1) * 3];
 		const float* v2 = &verts[(triIndex * 3 + 2) * 3];
-		if (!rasterizeTri(v0, v1, v2, areaIDs[triIndex], heightfield, heightfield.bmin, heightfield.bmax, heightfield.cs, inverseCellSize, inverseCellHeight, flagMergeThreshold))
+		if (!rasterizeTri(v0, v1, v2, triAreaIDs[triIndex], heightfield, heightfield.bmin, heightfield.bmax, heightfield.cs, inverseCellSize, inverseCellHeight, flagMergeThreshold))
 		{
 			context->log(RC_LOG_ERROR, "rcRasterizeTriangles: Out of memory.");
 			return false;


### PR DESCRIPTION
Zero functionality changes.  Just formatting changes, local var and parameter name changes, consolidating doc comments and fixing some rule-of-three violations.

Also added a constructor and destructor to rcPolyMeshDetail, since rcAllocPolyMeshDetail and rcFreePolyMeshDetail indicate these can't be trivially constructed or destructed safely like other POD types.