### PR TITLE
Fix for out of bounds read in tile cache builder.

### DIFF
--- a/DetourTileCache/Source/DetourTileCacheBuilder.cpp
+++ b/DetourTileCache/Source/DetourTileCacheBuilder.cpp
@@ -1558,7 +1558,7 @@ static dtStatus removeVertex(dtTileCachePolyMesh& mesh, const unsigned short rem
 	}
 	
 	// Remove vertex.
-	for (int i = (int)rem; i < mesh.nverts; ++i)
+	for (int i = (int)rem; i < mesh.nverts - 1; ++i)
 	{
 		mesh.verts[i*3+0] = mesh.verts[(i+1)*3+0];
 		mesh.verts[i*3+1] = mesh.verts[(i+1)*3+1];


### PR DESCRIPTION
Fix for reading data out of bounds in tile cache builder in removeVertex.
While removing a vertex data is read from i+1 index from mesh.verts, which becomes out of bound for the last vertex, which we shouldn't copy over in this case.