### PR TITLE
Gh pages deploy workflow

### DIFF
--- a/.github/workflows/Docs.yaml
+++ b/.github/workflows/Docs.yaml
@@ -1,0 +1,29 @@
+name: Publish Docs
+
+permissions:
+  contents: write
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install Doxygen
+        run: sudo apt-get install -y doxygen
+
+      - name: Build Doxygen Documentation
+        run: doxygen ./Doxyfile
+
+      - name: Deploy Documentation
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: ./Docs/html
+          branch: gh-pages

--- a/.github/workflows/Docs.yaml
+++ b/.github/workflows/Docs.yaml
@@ -6,6 +6,7 @@ permissions:
 on:
   push:
     branches: [main]
+  workflow_dispatch: {}
 
 jobs:
   deploy:

--- a/.github/workflows/Docs.yaml
+++ b/.github/workflows/Docs.yaml
@@ -4,8 +4,8 @@ permissions:
   contents: write
 
 on:
-  push: {}
-  workflow_dispatch: {}
+  push:
+    branches: [main]
 
 jobs:
   deploy:

--- a/.github/workflows/Docs.yaml
+++ b/.github/workflows/Docs.yaml
@@ -4,8 +4,7 @@ permissions:
   contents: write
 
 on:
-  push:
-    branches: [main]
+  push: {}
   workflow_dispatch: {}
 
 jobs:


### PR DESCRIPTION
Build and deploys doxygen docs to a gh-pages branch so they can be hosted in GitHub pages.