### PR TITLE
Increase epsilon in detour common segment polygon intersection test

### DIFF
--- a/Detour/Source/DetourCommon.cpp
+++ b/Detour/Source/DetourCommon.cpp
@@ -112,7 +112,7 @@ bool dtIntersectSegmentPoly2D(const float* p0, const float* p1,
 							  float& tmin, float& tmax,
 							  int& segMin, int& segMax)
 {
-	static const float EPS = 0.00000001f;
+	static const float EPS = 0.000001f;
 	
 	tmin = 0;
 	tmax = 1;


### PR DESCRIPTION
It's only used to detect if the segment is parallel to the polygon edge in question, and if so, skip actually doing the intersection test.  This sets the epsilon to 1e-6, which is about 10x the machine epsilon for 32bit floats, so it's low enough to not give false positives but it's large enough to correctly detect segments and polygon edges that are extremely close to parallel.

Fixes #607