### PR TITLE
Removed STL function from Detour

### DIFF
--- a/Detour/Include/DetourMath.h
+++ b/Detour/Include/DetourMath.h
@@ -8,9 +8,6 @@ Members in this module are wrappers around the standard math library
 #define DETOURMATH_H
 
 #include <math.h>
-// This include is required because libstdc++ has problems with isfinite
-// if cmath is included before math.h.
-#include <cmath>
 
 inline float dtMathFabsf(float x) { return fabsf(x); }
 inline float dtMathSqrtf(float x) { return sqrtf(x); }
@@ -19,6 +16,6 @@ inline float dtMathCeilf(float x) { return ceilf(x); }
 inline float dtMathCosf(float x) { return cosf(x); }
 inline float dtMathSinf(float x) { return sinf(x); }
 inline float dtMathAtan2f(float y, float x) { return atan2f(y, x); }
-inline bool dtMathIsfinite(float x) { return std::isfinite(x); }
+inline bool dtMathIsfinite(float x) { return isfinite(x); }
 
 #endif


### PR DESCRIPTION
Recast and Detour avoid STL and adhere to the C++03 standard to maximize compatibility.  `std::infinite` [was added in C++11](https://en.cppreference.com/w/cpp/numeric/math/isfinite) as a STD-namespaced version of the C `infinite` function in `math.h`.  