### PR TITLE
cmake configure for RC_MAX_LAYERS and RC_MAX_NEIS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,17 @@ endif()
 include(GNUInstallDirs)
 
 configure_file(
+    "${RecastNavigation_SOURCE_DIR}/config.h.in"
+    "${RecastNavigation_BINARY_DIR}/config.h")
+include_directories( ${PROJECT_BINARY_DIR} )
+SET(RC_MAX_LAYERS 63 CACHE STRING "Must be 255 or smaller (not 256) because layer IDs are stored as a byte where 255 is a special value.")
+SET(RC_MAX_NEIS 16 CACHE STRING "" FORCE)
+
+if(${RC_MAX_LAYERS} GREATER 255)
+	message(FATAL_ERROR "RC_MAX_LAYERS must be <= 255")
+endif()
+
+configure_file(
     "${RecastNavigation_SOURCE_DIR}/version.h.in"
     "${RecastNavigation_BINARY_DIR}/version.h")
 install(FILES "${RecastNavigation_BINARY_DIR}/version.h" DESTINATION

--- a/Recast/Source/RecastLayers.cpp
+++ b/Recast/Source/RecastLayers.cpp
@@ -26,11 +26,7 @@
 #include "RecastAlloc.h"
 #include "RecastAssert.h"
 
-
-// Must be 255 or smaller (not 256) because layer IDs are stored as
-// a byte where 255 is a special value.
-static const int RC_MAX_LAYERS = 63;
-static const int RC_MAX_NEIS = 16;
+#include <config.h>
 
 struct rcLayerRegion
 {

--- a/config.h.in
+++ b/config.h.in
@@ -1,0 +1,4 @@
+// Must be 255 or smaller (not 256) because layer IDs are stored as
+// a byte where 255 is a special value.
+#define RC_MAX_LAYERS ${RC_MAX_LAYERS}
+#define RC_MAX_NEIS ${RC_MAX_NEIS}


### PR DESCRIPTION
implements feature mentioned in #604 and discussed in #605

I added RC_MAX_NEIS in because why not. It could be improved by adding actual doc strings, but I'm not sure what I should write in there.
This also makes sure that RC_MAX_LAYERS can not be > 255, because why not too.