### PR TITLE
Fix spans being filtered even if they have just enough clearance.

### DIFF
--- a/Recast/Source/RecastFilter.cpp
+++ b/Recast/Source/RecastFilter.cpp
@@ -174,7 +174,7 @@ void rcFilterWalkableLowHeightSpans(rcContext* context, const int walkableHeight
 			{
 				const int bot = (int)(span->smax);
 				const int top = span->next ? (int)(span->next->smin) : MAX_HEIGHT;
-				if ((top - bot) <= walkableHeight)
+				if ((top - bot) < walkableHeight)
 				{
 					span->area = RC_NULL_AREA;
 				}


### PR DESCRIPTION
The function comment mentions that heights LESS THAN the walkable height will be marked unwalkable. The previous implementation filtered out heights with exactly walkable height space.