### PR TITLE
Changed asserts to be explicitly disabled with RC_DISABLE_ASSERTS rather than using NDEBUG

### DIFF
--- a/Detour/Include/DetourAssert.h
+++ b/Detour/Include/DetourAssert.h
@@ -22,7 +22,7 @@
 // Note: This header file's only purpose is to include define assert.
 // Feel free to change the file and include your own implementation instead.
 
-#ifdef NDEBUG
+#ifdef RC_DISABLE_ASSERTS
 
 // From https://web.archive.org/web/20210117002833/http://cnicholson.net/2009/02/stupid-c-tricks-adventures-in-assert/
 #	define dtAssert(x) do { (void)sizeof(x); } while((void)(__LINE__==-1),false)  

--- a/Detour/Source/DetourAssert.cpp
+++ b/Detour/Source/DetourAssert.cpp
@@ -18,7 +18,7 @@
 
 #include "DetourAssert.h"
 
-#ifndef NDEBUG
+#ifndef RC_DISABLE_ASSERTS
 
 static dtAssertFailFunc* sAssertFailFunc = 0;
 

--- a/Integration.md
+++ b/Integration.md
@@ -1,0 +1,32 @@
+# Integration
+
+There are a few ways to integrate Recast and Detour into your project.  Source integration is the most popular and most flexible, and is what the project was designed for from the beginning.
+
+## Source Integration
+
+It is recommended to add the source directories `DebugUtils`, `Detour`, `DetourCrowd`, `DetourTileCache`, and `Recast` directly into your project depending on which parts of the project you need. For example your level building tool could include `DebugUtils`, `Recast`, and `Detour`, and your game runtime could just include `Detour`.
+
+- *Recast*: Core navmesh building system.
+- *Detour*: Runtime navmesh interface and query system
+- *DetourCrowd*: Runtime movement, obstacle avoidance and crowd sim systems
+- *DetourTileCache*: Runtime navmesh dynamic obstacle and re-baking system
+
+## Install through vcpkg
+
+If you are using the [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager you can alternatively download and install Recast with:
+
+```
+vcpkg install recast
+```
+
+# DLL and C API exports
+
+Recast does not currently provide a stable C API for use in a DLL or as bindings for another language.  The design of Recast currently relies on some C++ features, so providing a stable API is not possible without a few large changes to Recast.  There are a number of projects that offer unofficial language bindings for Recast, but official support for a C API is currently on our [Roadmap](Roadmap.md).
+
+# Preprocessor defines
+
+`RC_DISABLE_ASSERTS`: Disables assertion macros.  Useful for release builds that need to maximize performance.
+
+`DT_POLYREF64`: Use 64 bit (rather than 32 bit) polygon ID references.  Generally not needed, but sometimes useful for very large worlds.
+
+`DT_VIRTUAL_QUERYFILTER`: Define this if you plan to sub-class `dtQueryFilter`.  Enables the virtual destructor in `dtQueryFilter`

--- a/README.md
+++ b/README.md
@@ -66,15 +66,7 @@ RecastDemo uses [premake5](http://premake.github.io/) to build platform specific
 
 ## Integrating with your game or engine
 
-It is recommended to add the source directories `DebugUtils`, `Detour`, `DetourCrowd`, `DetourTileCache`, and `Recast` into your own project depending on which parts of the project you need. For example your level building tool could include `DebugUtils`, `Recast`, and `Detour`, and your game runtime could just include `Detour`.
-
-### Install through vcpkg
-
-If you are using the [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager you can download and install Recast with:
-
-```
-vcpkg install recast
-```
+See [Integration.md](Integration.md)
 
 ## Contribute
 

--- a/Recast/Include/RecastAssert.h
+++ b/Recast/Include/RecastAssert.h
@@ -19,7 +19,7 @@
 #ifndef RECASTASSERT_H
 #define RECASTASSERT_H
 
-#ifdef NDEBUG
+#ifdef RC_DISABLE_ASSERTS
 
 // From https://web.archive.org/web/20210117002833/http://cnicholson.net/2009/02/stupid-c-tricks-adventures-in-assert/
 #	define rcAssert(x) do { (void)sizeof(x); } while ((void)(__LINE__==-1), false)

--- a/Recast/Source/RecastAssert.cpp
+++ b/Recast/Source/RecastAssert.cpp
@@ -18,7 +18,7 @@
 
 #include "RecastAssert.h"
 
-#ifndef NDEBUG
+#ifndef RC_DISABLE_ASSERTS
 
 static rcAssertFailFunc* sRecastAssertFailFunc = 0;
 

--- a/RecastDemo/premake5.lua
+++ b/RecastDemo/premake5.lua
@@ -28,7 +28,7 @@ workspace "recastnavigation"
  
  	-- release configs
 	filter "configurations:Release"
-		defines { "NDEBUG" }
+		defines { "RC_DISABLE_ASSERTS" }
 		optimize "On"
 		targetdir ( todir .. "/lib/Release" )
 


### PR DESCRIPTION
This gives explicit control to users over when recast asserts are enabled or disabled.  This is useful when users wish to disable asserts in debug mode or enable them in release mode.  e.g. it's common to compile game code in debug alongside third party code in release.

Also moved integration instructions to Integration.md and added descriptions for all the current preprocessor definitions.