### PR TITLE
[Detour] Fix 6 typos in the comments [ci skip]

### DIFF
--- a/Detour/Include/DetourNavMeshBuilder.h
+++ b/Detour/Include/DetourNavMeshBuilder.h
@@ -112,12 +112,12 @@ struct dtNavMeshCreateParams
 /// @return True if the tile data was successfully created.
 bool dtCreateNavMeshData(dtNavMeshCreateParams* params, unsigned char** outData, int* outDataSize);
 
-/// Swaps the endianess of the tile data's header (#dtMeshHeader).
+/// Swaps the endianness of the tile data's header (#dtMeshHeader).
 ///  @param[in,out]	data		The tile data array.
 ///  @param[in]		dataSize	The size of the data array.
 bool dtNavMeshHeaderSwapEndian(unsigned char* data, const int dataSize);
 
-/// Swaps endianess of the tile data.
+/// Swaps endianness of the tile data.
 ///  @param[in,out]	data		The tile data array.
 ///  @param[in]		dataSize	The size of the data array.
 bool dtNavMeshDataSwapEndian(unsigned char* data, const int dataSize);

--- a/Detour/Source/DetourNavMeshBuilder.cpp
+++ b/Detour/Source/DetourNavMeshBuilder.cpp
@@ -705,10 +705,10 @@ bool dtNavMeshHeaderSwapEndian(unsigned char* data, const int /*dataSize*/)
 
 /// @par
 ///
-/// @warning This function assumes that the header is in the correct endianess already. 
-/// Call #dtNavMeshHeaderSwapEndian() first on the data if the data is expected to be in wrong endianess 
+/// @warning This function assumes that the header is in the correct endianness already. 
+/// Call #dtNavMeshHeaderSwapEndian() first on the data if the data is expected to be in wrong endianness 
 /// to start with. Call #dtNavMeshHeaderSwapEndian() after the data has been swapped if converting from 
-/// native to foreign endianess.
+/// native to foreign endianness.
 bool dtNavMeshDataSwapEndian(unsigned char* data, const int /*dataSize*/)
 {
 	// Make sure the data is in right format.

--- a/DetourTileCache/Include/DetourTileCacheBuilder.h
+++ b/DetourTileCache/Include/DetourTileCacheBuilder.h
@@ -146,7 +146,7 @@ dtStatus dtBuildTileCachePolyMesh(dtTileCacheAlloc* alloc,
 								  dtTileCacheContourSet& lcset,
 								  dtTileCachePolyMesh& mesh);
 
-/// Swaps the endianess of the compressed tile data's header (#dtTileCacheLayerHeader).
+/// Swaps the endianness of the compressed tile data's header (#dtTileCacheLayerHeader).
 /// Tile layer data does not need endian swapping as it consist only of bytes.
 ///  @param[in,out]	data		The tile data array.
 ///  @param[in]		dataSize	The size of the data array.


### PR DESCRIPTION
fix same typo 6 times in the comment section of 3 `Detour` related files.