### PR TITLE
Fix queries on large nav meshes (DT_POLYREF64 enabled)

### DIFF
--- a/Detour/Include/DetourNode.h
+++ b/Detour/Include/DetourNode.h
@@ -28,7 +28,12 @@ enum dtNodeFlags
 	DT_NODE_PARENT_DETACHED = 0x04 // parent of the node is not adjacent. Found using raycast.
 };
 
+#ifdef DT_POLYREF64
+typedef unsigned int dtNodeIndex;
+#else 
 typedef unsigned short dtNodeIndex;
+#endif
+
 static const dtNodeIndex DT_NULL_IDX = (dtNodeIndex)~0;
 
 static const int DT_NODE_PARENT_BITS = 24;


### PR DESCRIPTION
This change fixes a previously changed piece of code that resulted in a segfault when querying on large navigation meshes. 

I believe it to have been an oversight to have changed the type from an int to a short, so I have included the ifdef. 