### PR TITLE
Fix premake linux demo build

### DIFF
--- a/RecastDemo/Source/main.cpp
+++ b/RecastDemo/Source/main.cpp
@@ -65,6 +65,7 @@ static SampleItem g_samples[] =
 	{ createSolo, "Solo Mesh" },
 	{ createTile, "Tile Mesh" },
 	{ createTempObstacle, "Temp Obstacles" },
+	{ createDebug, "Debug" },
 };
 static const int g_nsamples = sizeof(g_samples) / sizeof(SampleItem);
 


### PR DESCRIPTION
This is an attempt to fix this build error:

```
 ../../Source/main.cpp:62:16: error: unused function 'createDebug' [-Werror,-Wunused-function]
static Sample* createDebug() { return new Sample_Debug(); }
               ^
1 error generated.
```

I'm not sure this is correct. That line was commented out in:

- https://github.com/recastnavigation/recastnavigation/commit/f44e1515562ace8134241e66988773bc8ef503dc

Then it was removed later.

An alternative would be to entirely remove the `Sample_Debug` code.