### PR TITLE
fix findNearestPoly result error

### DIFF
--- a/Detour/Source/DetourNavMeshBuilder.cpp
+++ b/Detour/Source/DetourNavMeshBuilder.cpp
@@ -624,7 +624,7 @@ bool dtCreateNavMeshData(dtNavMeshCreateParams* params, unsigned char** outData,
 	// Store and create BVtree.
 	if (params->buildBvTree)
 	{
-		createBVTree(params, navBvtree, 2*params->polyCount);
+		header->bvNodeCount = createBVTree(params, navBvtree, 2*params->polyCount);
 	}
 	
 	// Store Off-Mesh connections.


### PR DESCRIPTION
bvNodeCount should be set to exactly the number of nodes in the bvTree. Otherwise dummy node of zero data may be traversed and the findNearestPoly get the wrong result.

Consider this case, ployCount is 6 and the number of valid node in bvTree is 11, thus leaving a dummy node which can be tranverse from the node with index 6 in the array. The dummy node‘s i, bmin, bmax value are all zero and may be decteted as overlapping with the query box.