### PR TITLE
Support enabling and disabling asserts for CMake builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ option(RECASTNAVIGATION_TESTS "Build tests" ON)
 option(RECASTNAVIGATION_EXAMPLES "Build examples" ON)
 option(RECASTNAVIGATION_DT_POLYREF64 "Use 64bit polyrefs instead of 32bit for Detour" OFF)
 option(RECASTNAVIGATION_DT_VIRTUAL_QUERYFILTER "Use dynamic dispatch for dtQueryFilter in Detour to allow for custom filters" OFF)
+option(RECASTNAVIGATION_ENABLE_ASSERTS "Enable custom recastnavigation asserts" "$<IF:$<CONFIG:Debug>,ON,OFF>")
 
 if(MSVC AND BUILD_SHARED_LIBS)
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)

--- a/Detour/CMakeLists.txt
+++ b/Detour/CMakeLists.txt
@@ -13,6 +13,10 @@ if(RECASTNAVIGATION_DT_VIRTUAL_QUERYFILTER)
     target_compile_definitions(Detour PUBLIC DT_VIRTUAL_QUERYFILTER)
 endif()
 
+if(NOT RECASTNAVIGATION_ENABLE_ASSERTS)
+    target_compile_definitions(Detour PUBLIC RC_DISABLE_ASSERTS)
+endif()
+
 target_include_directories(Detour PUBLIC
     "$<BUILD_INTERFACE:${Detour_INCLUDE_DIR}>"
 )

--- a/Recast/CMakeLists.txt
+++ b/Recast/CMakeLists.txt
@@ -10,6 +10,10 @@ target_include_directories(Recast PUBLIC
     "$<BUILD_INTERFACE:${Recast_INCLUDE_DIR}>"
 )
 
+if(NOT RECASTNAVIGATION_ENABLE_ASSERTS)
+    target_compile_definitions(Recast PUBLIC RC_DISABLE_ASSERTS)
+endif()
+
 set_target_properties(Recast PROPERTIES
         SOVERSION ${SOVERSION}
         VERSION ${LIB_VERSION}


### PR DESCRIPTION
Before this change asserts are enabled by default for CMake builds. This impacts performance. Add option to enable or disable asserts with default value depending on the build config. By default enable for Debug builds and disable for everything else.