### PR TITLE
fix turning point check in findStraightPath

### DIFF
--- a/Detour/Source/DetourNavMeshQuery.cpp
+++ b/Detour/Source/DetourNavMeshQuery.cpp
@@ -1902,7 +1902,7 @@ dtStatus dtNavMeshQuery::findStraightPath(const float* startPos, const float* en
 			// Right vertex.
 			if (dtTriArea2D(portalApex, portalRight, right) <= 0.0f)
 			{
-				if (dtVequal(portalApex, portalRight) || dtTriArea2D(portalApex, portalLeft, right) > 0.0f)
+				if (dtVequal(portalApex, portalRight) || dtVequal(right, portalRight) || dtTriArea2D(portalApex, portalLeft, right) >= 0.0f)
 				{
 					dtVcopy(portalRight, right);
 					rightPolyRef = (i+1 < pathSize) ? path[i+1] : 0;
@@ -1953,7 +1953,7 @@ dtStatus dtNavMeshQuery::findStraightPath(const float* startPos, const float* en
 			// Left vertex.
 			if (dtTriArea2D(portalApex, portalLeft, left) >= 0.0f)
 			{
-				if (dtVequal(portalApex, portalLeft) || dtTriArea2D(portalApex, portalRight, left) < 0.0f)
+				if (dtVequal(portalApex, portalLeft) || dtVequal(left, portalLeft) || dtTriArea2D(portalApex, portalRight, left) <= 0.0f)
 				{
 					dtVcopy(portalLeft, left);
 					leftPolyRef = (i+1 < pathSize) ? path[i+1] : 0;


### PR DESCRIPTION
This commit try to prevent inappropriate turning point by accepting overlapped points as new ```portalLeft``` or ```portalRight```.

Detailed reason for this is discussed in [issue#735](https://github.com/recastnavigation/recastnavigation/issues/735).