### PR TITLE
Disable calls to isfinite when compiling with -ffast-math

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -83,7 +83,7 @@ jobs:
           - clang
           - gcc
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -91,8 +91,9 @@ jobs:
     - name: Install opengl and SDL
       run: |
         sudo apt-get update
-        sudo apt-get install -y libgl1-mesa-dev libglu1-mesa-dev libsdl2-dev clang
+        sudo apt-get install -y libgl1-mesa-dev libglu1-mesa-dev libsdl2-dev clang gcc
         clang --version
+        gcc --version
 
     - name: Download & Install premake
       working-directory: RecastDemo

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -91,7 +91,8 @@ jobs:
     - name: Install opengl and SDL
       run: |
         sudo apt-get update
-        sudo apt-get install -y libgl1-mesa-dev libglu1-mesa-dev libsdl2-dev
+        sudo apt-get install -y libgl1-mesa-dev libglu1-mesa-dev libsdl2-dev clang
+        clang --version
 
     - name: Download & Install premake
       working-directory: RecastDemo

--- a/Detour/Include/DetourMath.h
+++ b/Detour/Include/DetourMath.h
@@ -22,6 +22,7 @@ inline bool dtMathIsfinite(float x)
 	return isfinite(x);
 #else
 	// Infinity and NaN are disabled when compiling with -ffast-math
+	(void)x;
 	return true;
 #endif
 }

--- a/Detour/Include/DetourMath.h
+++ b/Detour/Include/DetourMath.h
@@ -16,6 +16,14 @@ inline float dtMathCeilf(float x) { return ceilf(x); }
 inline float dtMathCosf(float x) { return cosf(x); }
 inline float dtMathSinf(float x) { return sinf(x); }
 inline float dtMathAtan2f(float y, float x) { return atan2f(y, x); }
-inline bool dtMathIsfinite(float x) { return isfinite(x); }
+inline bool dtMathIsfinite(float x)
+{
+#ifndef RC_FAST_MATH
+	return isfinite(x);
+#else
+	// Infinity and NaN are disabled when compiling with -ffast-math
+	return true;
+#endif
+}
 
 #endif

--- a/DetourTileCache/Source/DetourTileCacheBuilder.cpp
+++ b/DetourTileCache/Source/DetourTileCacheBuilder.cpp
@@ -1504,19 +1504,6 @@ static bool canRemoveVertex(dtTileCachePolyMesh& mesh, const unsigned short rem)
 
 static dtStatus removeVertex(dtTileCachePolyMesh& mesh, const unsigned short rem, const int maxTris)
 {
-	// Count number of polygons to remove.
-	int numRemovedVerts = 0;
-	for (int i = 0; i < mesh.npolys; ++i)
-	{
-		unsigned short* p = &mesh.polys[i*MAX_VERTS_PER_POLY*2];
-		const int nv = countPolyVerts(p);
-		for (int j = 0; j < nv; ++j)
-		{
-			if (p[j] == rem)
-				numRemovedVerts++;
-		}
-	}
-	
 	int nedges = 0;
 	unsigned short edges[MAX_REM_EDGES*3];
 	int nhole = 0;

--- a/RecastDemo/premake5.lua
+++ b/RecastDemo/premake5.lua
@@ -247,8 +247,11 @@ project "Tests"
 
 	-- enable ubsan and asan when compiling with clang
 	filter "toolset:clang"
-			buildoptions { "-fsanitize=undefined", "-fsanitize=address" } -- , "-fsanitize=memory" }
-			linkoptions { "-fsanitize=undefined", "-fsanitize=address" } --, "-fsanitize=memory" }
+		-- Disable `-Wnan-infinity-disabled` because Catch uses functions like std::isnan() that
+		-- generate warnings when compiled with -ffast-math.
+		buildoptions { "-Wno-nan-infinity-disabled" }
+		buildoptions { "-fsanitize=undefined", "-fsanitize=address" } -- , "-fsanitize=memory" }
+		linkoptions { "-fsanitize=undefined", "-fsanitize=address" } --, "-fsanitize=memory" }
 
 	-- linux library cflags and libs
 	filter "system:linux"

--- a/RecastDemo/premake5.lua
+++ b/RecastDemo/premake5.lua
@@ -14,7 +14,13 @@ workspace "recastnavigation"
 
 	location (todir)
 
+	-- Use fast math operations.  This is not required, but it speeds up some calculations 
+	-- at the expense of accuracy.  Because there are some functions like dtMathIsfinite 
+	-- that use floating point functions that become undefined behavior when compiled with
+	-- fast-math, we need to conditionally short-circuit these functions.
 	floatingpoint "Fast"
+	defines { "RC_FAST_MATH" }
+
 	exceptionhandling "Off"
 	rtti "Off"
 	symbols "On"


### PR DESCRIPTION
Fast math is not required, but it speeds up some calculations at the expense of accuracy.  There are some functions like dtMathIsfinite that use floating point functions that become undefined behavior when compiled with fast-math, so we need to conditionally short-circuit these functions when compiled with that flag.

`-Wnan-infinity-disabled` was added in Clang 18 and is complaining about this `isfinite` call in `dtMathIsfinite`.  

This also sets the linux runner explicitly to Ubuntu 24.04, since `ubuntu-latest` defaults to 22.04 for some reason.  This also updates gcc and clang to the latest versions in apt and logs their version to the run output.

Finally, this also removes some unused code that was throwing a warning (and thus an error) on newer compiler versions.