### PR TITLE
Use newer clang and ubuntu version when building linux tests project

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -41,7 +41,7 @@ jobs:
       run: ./Tests --verbosity high --success
   
   linux-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v3
@@ -49,7 +49,8 @@ jobs:
     - name: Install opengl and SDL
       run: |
         sudo apt-get update
-        sudo apt-get install -y libgl1-mesa-dev libglu1-mesa-dev libsdl2-dev
+        sudo apt-get install -y libgl1-mesa-dev libglu1-mesa-dev libsdl2-dev clang
+        clang --version
 
     - name: Download & Install premake
       working-directory: RecastDemo


### PR DESCRIPTION
Since we need to build with clang 18 and ubuntu-latest is still set to 22.04 which uses clang 14.