### PR TITLE
Explicitly specify Ubuntu 24.04 rather than ubuntu-latest

### DIFF
--- a/.github/workflows/Docs.yaml
+++ b/.github/workflows/Docs.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
Since ubuntu-latest is using 22.04, and the version of doxygen it uses is generating some incorrect headers.