### PR TITLE
Explicitly use html tags in Changelog to work around bug in doxygen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/recastnavigation/recastnavigation/compare/1.6.0...HEAD)
-
-## [1.6.0](https://github.com/recastnavigation/recastnavigation/compare/1.5.1...1.6.0) - 2023-05-21
+<h2>[Unreleased](https://github.com/recastnavigation/recastnavigation/compare/1.6.0...HEAD)</h2>
+<h2>[1.6.0](https://github.com/recastnavigation/recastnavigation/compare/1.5.1...1.6.0) - 2023-05-21</h2>
 
 ### Added
 - CMake build support


### PR DESCRIPTION
There's a bug in doxygen's markdown html generator when specifying header text that's just link text.  This is fixed in newer versions of doxygen, but the ubuntu images in github actions runners don't have a new enough version to work around this.  Instead, just write out the html explicitly for now.