### PR TITLE
Don't remove custom assert failure registering code when disabling assertions

### DIFF
--- a/Recast/Include/RecastAssert.h
+++ b/Recast/Include/RecastAssert.h
@@ -19,27 +19,24 @@
 #ifndef RECASTASSERT_H
 #define RECASTASSERT_H
 
-#ifdef RC_DISABLE_ASSERTS
-
-// From https://web.archive.org/web/20210117002833/http://cnicholson.net/2009/02/stupid-c-tricks-adventures-in-assert/
-#	define rcAssert(x) do { (void)sizeof(x); } while ((void)(__LINE__==-1), false)
-
-#else
-
-/// An assertion failure function.
-//  @param[in]		expression  asserted expression.
-//  @param[in]		file  Filename of the failed assertion.
-//  @param[in]		line  Line number of the failed assertion.
-///  @see rcAssertFailSetCustom
+/// An assertion failure callback function.
+/// @param[in]  expression  Asserted expression.
+/// @param[in]  file        Filename of the failed assertion.
+/// @param[in]  line        Line number of the failed assertion.
+/// @see rcAssertFailSetCustom
 typedef void (rcAssertFailFunc)(const char* expression, const char* file, int line);
 
-/// Sets the base custom assertion failure function to be used by Recast.
-///  @param[in]		assertFailFunc	The function to be used in case of failure of #dtAssert
+/// Sets the base custom assertion failure callback function to be used by Recast.
+/// @param[in]  assertFailFunc  The function to be used in case of failure of #dtAssert
 void rcAssertFailSetCustom(rcAssertFailFunc* assertFailFunc);
 
 /// Gets the base custom assertion failure function to be used by Recast.
 rcAssertFailFunc* rcAssertFailGetCustom();
 
+#ifdef RC_DISABLE_ASSERTS
+// From https://web.archive.org/web/20210117002833/http://cnicholson.net/2009/02/stupid-c-tricks-adventures-in-assert/
+#	define rcAssert(x) do { (void)sizeof(x); } while ((void)(__LINE__==-1), false)
+#else
 #	include <assert.h> 
 #	define rcAssert(expression) \
 		{ \
@@ -47,7 +44,6 @@ rcAssertFailFunc* rcAssertFailGetCustom();
 			if (failFunc == NULL) { assert(expression); } \
 			else if (!(expression)) { (*failFunc)(#expression, __FILE__, __LINE__); } \
 		}
-
-#endif
+#endif // !defined(RC_DISABLE_ASSERTS)
 
 #endif // RECASTASSERT_H

--- a/Recast/Source/RecastAssert.cpp
+++ b/Recast/Source/RecastAssert.cpp
@@ -18,8 +18,6 @@
 
 #include "RecastAssert.h"
 
-#ifndef RC_DISABLE_ASSERTS
-
 static rcAssertFailFunc* sRecastAssertFailFunc = 0;
 
 void rcAssertFailSetCustom(rcAssertFailFunc* assertFailFunc)
@@ -31,5 +29,3 @@ rcAssertFailFunc* rcAssertFailGetCustom()
 {
 	return sRecastAssertFailFunc;
 }
-
-#endif


### PR DESCRIPTION
Otherwise, client code that calls these custom assertion failure callback registration functions will break when disabling asserts.