### PR TITLE
Add exit condition to raycast() if DT_BUFFER_TOO_SMALL

### DIFF
--- a/Detour/Source/DetourNavMeshQuery.cpp
+++ b/Detour/Source/DetourNavMeshQuery.cpp
@@ -2681,6 +2681,12 @@ dtStatus dtNavMeshQuery::raycast(dtPolyRef startRef, const float* startPos, cons
 		tile = nextTile;
 		prevPoly = poly;
 		poly = nextPoly;
+
+		if (status & DT_BUFFER_TOO_SMALL)
+		{
+			status |= DT_PARTIAL_RESULT;
+			break;
+		}
 	}
 	
 	hit->pathCount = n;


### PR DESCRIPTION
If an underlying `dtNavMesh` is sufficiently low quality, then there is a chance that `raycast()` can get stuck in an infinite loop (see https://github.com/recastnavigation/recastnavigation/issues/436). This is also the case I found earlier today in my own codebase.

In the linked issue, they mention their loop looks like: `A -> B -> C -> A` for polyRefs. In my case, it's flipping between `A -> B -> A`

In this section:
https://github.com/recastnavigation/recastnavigation/blob/main/Detour/Source/DetourNavMeshQuery.cpp#L2540-L2544
We determine that we've reached the end of the buffer, but we never report failure or even a partial result. This PR does that.

This block could be moved up, or it could also be changed to `DT_FAILURE`

It fixes the issue in my codebase.

Fixes https://github.com/recastnavigation/recastnavigation/issues/436