### PR TITLE
`dtNavMesh::connectExtLinks` make max number of neighbors per edge configurable

### DIFF
--- a/Detour/Include/DetourNavMesh.h
+++ b/Detour/Include/DetourNavMesh.h
@@ -56,6 +56,10 @@ typedef uint64_t dtTileRef;
 typedef unsigned int dtTileRef;
 #endif
 
+#ifndef DT_MAX_NEI_PER_EDGE
+#define DT_MAX_NEI_PER_EDGE 4
+#endif
+
 /// The maximum number of vertices per navigation polygon.
 /// @ingroup detour
 static const int DT_VERTS_PER_POLYGON = 6;
@@ -635,7 +639,7 @@ private:
 	void baseOffMeshLinks(dtMeshTile* tile);
 
 	/// Builds external polygon links for a tile.
-	void connectExtLinks(dtMeshTile* tile, dtMeshTile* target, int side);
+	dtStatus connectExtLinks(dtMeshTile* tile, dtMeshTile* target, int side);
 	/// Builds external polygon links for a tile.
 	void connectExtOffMeshLinks(dtMeshTile* tile, dtMeshTile* target, int side);
 	


### PR DESCRIPTION
Background: In current version of `dtNavMesh::connectExtLinks`,  the method `findConnectingPolys` is called with the fixed parameter `maxcon` of 4. And all the neighbors per edge exceeding this limit will be dropped without any warnings.

What: I add a macro `DT_MAX_NEI_PER_EDGE` to support configurable number of neighbour per edge, and decide to raise an error when the number of neighbors exceeds this limit.