### PR TITLE
chore: ensure the bits of poly ref do not overflow.

### DIFF
--- a/Detour/Source/DetourNavMesh.cpp
+++ b/Detour/Source/DetourNavMesh.cpp
@@ -254,6 +254,10 @@ dtStatus dtNavMesh::init(const dtNavMeshParams* params)
 #ifndef DT_POLYREF64
 	m_tileBits = dtIlog2(dtNextPow2((unsigned int)params->maxTiles));
 	m_polyBits = dtIlog2(dtNextPow2((unsigned int)params->maxPolys));
+
+    // Ensure that the bits of poly ref do not overflow.
+    dtAssert(m_tileBits + m_polyBits <= 31);
+
 	// Only allow 31 salt bits, since the salt mask is calculated using 32bit uint and it will overflow.
 	m_saltBits = dtMin((unsigned int)31, 32 - m_tileBits - m_polyBits);
 


### PR DESCRIPTION
If there is an overflow, the nav mesh query will return incorrect results.