### PR TITLE
Remove the deprecated rcIntArray

### DIFF
--- a/Recast/Include/RecastAlloc.h
+++ b/Recast/Include/RecastAlloc.h
@@ -363,27 +363,6 @@ public:
 	rcPermVector(const T* begin, const T* end) : Base(begin, end) {}
 };
 
-/// Legacy class. Prefer rcVector<int>.
-class rcIntArray
-{
-	rcTempVector<int> m_impl;
-public:
-	rcIntArray() {}
-	rcIntArray(int n) : m_impl(n, 0) {}
-	void push(int item) { m_impl.push_back(item); }
-	void resize(int size) { m_impl.resize(size); }
-	void clear() { m_impl.clear(); }
-	int pop()
-	{
-		int v = m_impl.back();
-		m_impl.pop_back();
-		return v;
-	}
-	int size() const { return static_cast<int>(m_impl.size()); }
-	int& operator[](int index) { return m_impl[index]; }
-	int operator[](int index) const { return m_impl[index]; }
-};
-
 /// A simple helper class used to delete an array when it goes out of scope.
 /// @note This class is rarely if ever used by the end user.
 template<class T> class rcScopedDelete

--- a/Recast/Source/RecastContour.cpp
+++ b/Recast/Source/RecastContour.cpp
@@ -102,7 +102,7 @@ static int getCornerHeight(int x, int y, int i, int dir,
 
 static void walkContour(int x, int y, int i,
 						const rcCompactHeightfield& chf,
-						unsigned char* flags, rcIntArray& points)
+						unsigned char* flags, rcTempVector<int>& points)
 {
 	// Choose the first non-connected edge
 	unsigned char dir = 0;
@@ -146,10 +146,10 @@ static void walkContour(int x, int y, int i,
 				r |= RC_BORDER_VERTEX;
 			if (isAreaBorder)
 				r |= RC_AREA_BORDER;
-			points.push(px);
-			points.push(py);
-			points.push(pz);
-			points.push(r);
+			points.push_back(px);
+			points.push_back(py);
+			points.push_back(pz);
+			points.push_back(r);
 			
 			flags[i] &= ~(1 << dir); // Remove visited edges
 			dir = (dir+1) & 0x3;  // Rotate CW
@@ -206,7 +206,7 @@ static float distancePtSeg(const int x, const int z,
 	return dx*dx + dz*dz;
 }
 
-static void simplifyContour(rcIntArray& points, rcIntArray& simplified,
+static void simplifyContour(rcTempVector<int>& points, rcTempVector<int>& simplified,
 							const float maxError, const int maxEdgeLen, const int buildFlags)
 {
 	// Add initial points.
@@ -231,10 +231,10 @@ static void simplifyContour(rcIntArray& points, rcIntArray& simplified,
 			const bool areaBorders = (points[i*4+3] & RC_AREA_BORDER) != (points[ii*4+3] & RC_AREA_BORDER);
 			if (differentRegs || areaBorders)
 			{
-				simplified.push(points[i*4+0]);
-				simplified.push(points[i*4+1]);
-				simplified.push(points[i*4+2]);
-				simplified.push(i);
+				simplified.push_back(points[i*4+0]);
+				simplified.push_back(points[i*4+1]);
+				simplified.push_back(points[i*4+2]);
+				simplified.push_back(i);
 			}
 		}
 	}
@@ -272,15 +272,15 @@ static void simplifyContour(rcIntArray& points, rcIntArray& simplified,
 				uri = i/4;
 			}
 		}
-		simplified.push(llx);
-		simplified.push(lly);
-		simplified.push(llz);
-		simplified.push(lli);
+		simplified.push_back(llx);
+		simplified.push_back(lly);
+		simplified.push_back(llz);
+		simplified.push_back(lli);
 		
-		simplified.push(urx);
-		simplified.push(ury);
-		simplified.push(urz);
-		simplified.push(uri);
+		simplified.push_back(urx);
+		simplified.push_back(ury);
+		simplified.push_back(urz);
+		simplified.push_back(uri);
 	}
 	
 	// Add points until all raw points are within
@@ -576,7 +576,7 @@ static bool	inCone(int i, int n, const int* verts, const int* pj)
 }
 
 
-static void removeDegenerateSegments(rcIntArray& simplified)
+static void removeDegenerateSegments(rcTempVector<int>& simplified)
 {
 	// Remove adjacent vertices which are equal on xz-plane,
 	// or else the triangulator will get confused.
@@ -900,8 +900,8 @@ bool rcBuildContours(rcContext* ctx, const rcCompactHeightfield& chf,
 	
 	ctx->stopTimer(RC_TIMER_BUILD_CONTOURS_TRACE);
 	
-	rcIntArray verts(256);
-	rcIntArray simplified(64);
+	rcTempVector<int> verts(256);
+	rcTempVector<int> simplified(64);
 	
 	for (int y = 0; y < h; ++y)
 	{

--- a/Recast/Source/RecastMeshDetail.cpp
+++ b/Recast/Source/RecastMeshDetail.cpp
@@ -457,7 +457,7 @@ static void completeFacet(rcContext* ctx, const float* pts, int npts, int* edges
 
 static void delaunayHull(rcContext* ctx, const int npts, const float* pts,
 						 const int nhull, const int* hull,
-						 rcIntArray& tris, rcIntArray& edges)
+						 rcTempVector<int>& tris, rcTempVector<int>& edges)
 {
 	int nfaces = 0;
 	int nedges = 0;
@@ -556,7 +556,7 @@ static float polyMinExtent(const float* verts, const int nverts)
 inline int prev(int i, int n) { return i-1 >= 0 ? i-1 : n-1; }
 inline int next(int i, int n) { return i+1 < n ? i+1 : 0; }
 
-static void triangulateHull(const int /*nverts*/, const float* verts, const int nhull, const int* hull, const int nin, rcIntArray& tris)
+static void triangulateHull(const int /*nverts*/, const float* verts, const int nhull, const int* hull, const int nin, rcTempVector<int>& tris)
 {
 	int start = 0, left = 1, right = nhull-1;
 	
@@ -582,10 +582,10 @@ static void triangulateHull(const int /*nverts*/, const float* verts, const int 
 	}
 	
 	// Add first triangle
-	tris.push(hull[start]);
-	tris.push(hull[left]);
-	tris.push(hull[right]);
-	tris.push(0);
+	tris.push_back(hull[start]);
+	tris.push_back(hull[left]);
+	tris.push_back(hull[right]);
+	tris.push_back(0);
 	
 	// Triangulate the polygon by moving left or right,
 	// depending on which triangle has shorter perimeter.
@@ -606,18 +606,18 @@ static void triangulateHull(const int /*nverts*/, const float* verts, const int 
 		
 		if (dleft < dright)
 		{
-			tris.push(hull[left]);
-			tris.push(hull[nleft]);
-			tris.push(hull[right]);
-			tris.push(0);
+			tris.push_back(hull[left]);
+			tris.push_back(hull[nleft]);
+			tris.push_back(hull[right]);
+			tris.push_back(0);
 			left = nleft;
 		}
 		else
 		{
-			tris.push(hull[left]);
-			tris.push(hull[nright]);
-			tris.push(hull[right]);
-			tris.push(0);
+			tris.push_back(hull[left]);
+			tris.push_back(hull[nright]);
+			tris.push_back(hull[right]);
+			tris.push_back(0);
 			right = nright;
 		}
 	}
@@ -650,7 +650,7 @@ static bool onHull(int a, int b, int nhull, int* hull)
 }
 
 // Find edges that lie on hull and mark them as such.
-static void setTriFlags(rcIntArray& tris, int nhull, int* hull)
+static void setTriFlags(rcTempVector<int>& tris, int nhull, int* hull)
 {
 	// Matches DT_DETAIL_EDGE_BOUNDARY
 	const int DETAIL_EDGE_BOUNDARY = 0x1;
@@ -672,7 +672,7 @@ static bool buildPolyDetail(rcContext* ctx, const float* in, const int nin,
 							const float sampleDist, const float sampleMaxError,
 							const int heightSearchRadius, const rcCompactHeightfield& chf,
 							const rcHeightPatch& hp, float* verts, int& nverts,
-							rcIntArray& tris, rcIntArray& edges, rcIntArray& samples)
+							rcTempVector<int>& tris, rcTempVector<int>& edges, rcTempVector<int>& samples)
 {
 	static const int MAX_VERTS = 127;
 	static const int MAX_TRIS = 255;	// Max tris for delaunay is 2n-2-k (n=num verts, k=num hull verts).
@@ -848,10 +848,10 @@ static bool buildPolyDetail(rcContext* ctx, const float* in, const int nin,
 				pt[2] = z*sampleDist;
 				// Make sure the samples are not too close to the edges.
 				if (distToPoly(nin,in,pt) > -sampleDist/2) continue;
-				samples.push(x);
-				samples.push(getHeight(pt[0], pt[1], pt[2], cs, ics, chf.ch, heightSearchRadius, hp));
-				samples.push(z);
-				samples.push(0); // Not added
+				samples.push_back(x);
+				samples.push_back(getHeight(pt[0], pt[1], pt[2], cs, ics, chf.ch, heightSearchRadius, hp));
+				samples.push_back(z);
+				samples.push_back(0); // Not added
 			}
 		}
 		
@@ -919,7 +919,7 @@ static bool buildPolyDetail(rcContext* ctx, const float* in, const int nin,
 static void seedArrayWithPolyCenter(rcContext* ctx, const rcCompactHeightfield& chf,
 									const unsigned short* poly, const int npoly,
 									const unsigned short* verts, const int bs,
-									rcHeightPatch& hp, rcIntArray& array)
+									rcHeightPatch& hp, rcTempVector<int>& array)
 {
 	// Note: Reads to the compact heightfield are offset by border size (bs)
 	// since border size offset is already removed from the polymesh vertices.
@@ -972,9 +972,9 @@ static void seedArrayWithPolyCenter(rcContext* ctx, const rcCompactHeightfield& 
 	
 	// Use seeds array as a stack for DFS
 	array.clear();
-	array.push(startCellX);
-	array.push(startCellY);
-	array.push(startSpanIndex);
+	array.push_back(startCellX);
+	array.push_back(startCellY);
+	array.push_back(startSpanIndex);
 
 	int dirs[] = { 0, 1, 2, 3 };
 	memset(hp.data, 0, sizeof(unsigned short)*hp.width*hp.height);
@@ -991,9 +991,9 @@ static void seedArrayWithPolyCenter(rcContext* ctx, const rcCompactHeightfield& 
 			break;
 		}
 
-		ci = array.pop();
-		cy = array.pop();
-		cx = array.pop();
+		ci = array.back(); array.pop_back();
+		cy = array.back(); array.pop_back();
+		cx = array.back(); array.pop_back();
 
 		if (cx == pcx && cy == pcy)
 			break;
@@ -1029,9 +1029,9 @@ static void seedArrayWithPolyCenter(rcContext* ctx, const rcCompactHeightfield& 
 				continue;
 
 			hp.data[hpx+hpy*hp.width] = 1;
-			array.push(newX);
-			array.push(newY);
-			array.push((int)chf.cells[(newX+bs)+(newY+bs)*chf.width].index + rcGetCon(cs, dir));
+			array.push_back(newX);
+			array.push_back(newY);
+			array.push_back((int)chf.cells[(newX+bs)+(newY+bs)*chf.width].index + rcGetCon(cs, dir));
 		}
 
 		rcSwap(dirs[directDir], dirs[3]);
@@ -1039,9 +1039,9 @@ static void seedArrayWithPolyCenter(rcContext* ctx, const rcCompactHeightfield& 
 
 	array.clear();
 	// getHeightData seeds are given in coordinates with borders
-	array.push(cx+bs);
-	array.push(cy+bs);
-	array.push(ci);
+	array.push_back(cx+bs);
+	array.push_back(cy+bs);
+	array.push_back(ci);
 
 	memset(hp.data, 0xff, sizeof(unsigned short)*hp.width*hp.height);
 	const rcCompactSpan& cs = chf.spans[ci];
@@ -1049,7 +1049,7 @@ static void seedArrayWithPolyCenter(rcContext* ctx, const rcCompactHeightfield& 
 }
 
 
-static void push3(rcIntArray& queue, int v1, int v2, int v3)
+static void push3(rcTempVector<int>& queue, int v1, int v2, int v3)
 {
 	queue.resize(queue.size() + 3);
 	queue[queue.size() - 3] = v1;
@@ -1060,7 +1060,7 @@ static void push3(rcIntArray& queue, int v1, int v2, int v3)
 static void getHeightData(rcContext* ctx, const rcCompactHeightfield& chf,
 						  const unsigned short* poly, const int npoly,
 						  const unsigned short* verts, const int bs,
-						  rcHeightPatch& hp, rcIntArray& queue,
+						  rcHeightPatch& hp, rcTempVector<int>& queue,
 						  int region)
 {
 	// Note: Reads to the compact heightfield are offset by border size (bs)
@@ -1197,10 +1197,10 @@ bool rcBuildPolyMeshDetail(rcContext* ctx, const rcPolyMesh& mesh, const rcCompa
 	const int borderSize = mesh.borderSize;
 	const int heightSearchRadius = rcMax(1, (int)ceilf(mesh.maxEdgeError));
 	
-	rcIntArray edges(64);
-	rcIntArray tris(512);
-	rcIntArray arr(512);
-	rcIntArray samples(512);
+	rcTempVector<int> edges(64);
+	rcTempVector<int> tris(512);
+	rcTempVector<int> arr(512);
+	rcTempVector<int> samples(512);
 	float verts[256*3];
 	rcHeightPatch hp;
 	int nPolyVerts = 0;

--- a/Recast/Source/RecastRegion.cpp
+++ b/Recast/Source/RecastRegion.cpp
@@ -540,8 +540,8 @@ struct rcRegion
 	bool overlap;
 	bool connectsToBorder;
 	unsigned short ymin, ymax;
-	rcIntArray connections;
-	rcIntArray floors;
+	rcTempVector<int> connections;
+	rcTempVector<int> floors;
 };
 
 static void removeAdjacentNeighbours(rcRegion& reg)
@@ -555,7 +555,7 @@ static void removeAdjacentNeighbours(rcRegion& reg)
 			// Remove duplicate
 			for (int j = i; j < reg.connections.size()-1; ++j)
 				reg.connections[j] = reg.connections[j+1];
-			reg.connections.pop();
+			reg.connections.pop_back();
 		}
 		else
 			++i;
@@ -607,7 +607,7 @@ static void addUniqueFloorRegion(rcRegion& reg, int n)
 	for (int i = 0; i < reg.floors.size(); ++i)
 		if (reg.floors[i] == n)
 			return;
-	reg.floors.push(n);
+	reg.floors.push_back(n);
 }
 
 static bool mergeRegions(rcRegion& rega, rcRegion& regb)
@@ -616,11 +616,11 @@ static bool mergeRegions(rcRegion& rega, rcRegion& regb)
 	unsigned short bid = regb.id;
 	
 	// Duplicate current neighbourhood.
-	rcIntArray acon;
+	rcTempVector<int> acon;
 	acon.resize(rega.connections.size());
 	for (int i = 0; i < rega.connections.size(); ++i)
 		acon[i] = rega.connections[i];
-	rcIntArray& bcon = regb.connections;
+	rcTempVector<int>& bcon = regb.connections;
 	
 	// Find insertion point on A.
 	int insa = -1;
@@ -651,10 +651,10 @@ static bool mergeRegions(rcRegion& rega, rcRegion& regb)
 	// Merge neighbours.
 	rega.connections.clear();
 	for (int i = 0, ni = acon.size(); i < ni-1; ++i)
-		rega.connections.push(acon[(insa+1+i) % ni]);
+		rega.connections.push_back(acon[(insa+1+i) % ni]);
 		
 	for (int i = 0, ni = bcon.size(); i < ni-1; ++i)
-		rega.connections.push(bcon[(insb+1+i) % ni]);
+		rega.connections.push_back(bcon[(insb+1+i) % ni]);
 	
 	removeAdjacentNeighbours(rega);
 	
@@ -699,7 +699,7 @@ static bool isSolidEdge(rcCompactHeightfield& chf, const unsigned short* srcReg,
 static void walkContour(int x, int y, int i, int dir,
 						rcCompactHeightfield& chf,
 						const unsigned short* srcReg,
-						rcIntArray& cont)
+						rcTempVector<int>& cont)
 {
 	int startDir = dir;
 	int starti = i;
@@ -713,7 +713,7 @@ static void walkContour(int x, int y, int i, int dir,
 		const int ai = (int)chf.cells[ax+ay*chf.width].index + rcGetCon(ss, dir);
 		curReg = srcReg[ai];
 	}
-	cont.push(curReg);
+	cont.push_back(curReg);
 			
 	int iter = 0;
 	while (++iter < 40000)
@@ -734,7 +734,7 @@ static void walkContour(int x, int y, int i, int dir,
 			if (r != curReg)
 			{
 				curReg = r;
-				cont.push(curReg);
+				cont.push_back(curReg);
 			}
 			
 			dir = (dir+1) & 0x3;  // Rotate CW
@@ -776,7 +776,7 @@ static void walkContour(int x, int y, int i, int dir,
 			{
 				for (int k = j; k < cont.size()-1; ++k)
 					cont[k] = cont[k+1];
-				cont.pop();
+				cont.pop_back();
 			}
 			else
 				++j;
@@ -788,7 +788,7 @@ static void walkContour(int x, int y, int i, int dir,
 static bool mergeAndFilterRegions(rcContext* ctx, int minRegionArea, int mergeRegionSize,
 								  unsigned short& maxRegionId,
 								  rcCompactHeightfield& chf,
-								  unsigned short* srcReg, rcIntArray& overlaps)
+								  unsigned short* srcReg, rcTempVector<int>& overlaps)
 {
 	const int w = chf.width;
 	const int h = chf.height;
@@ -859,8 +859,8 @@ static bool mergeAndFilterRegions(rcContext* ctx, int minRegionArea, int mergeRe
 	}
 
 	// Remove too small regions.
-	rcIntArray stack(32);
-	rcIntArray trace(32);
+	rcTempVector<int> stack(32);
+	rcTempVector<int> trace(32);
 	for (int i = 0; i < nreg; ++i)
 	{
 		rcRegion& reg = regions[i];
@@ -879,17 +879,17 @@ static bool mergeAndFilterRegions(rcContext* ctx, int minRegionArea, int mergeRe
 		trace.clear();
 
 		reg.visited = true;
-		stack.push(i);
+		stack.push_back(i);
 		
 		while (stack.size())
 		{
 			// Pop
-			int ri = stack.pop();
+			int ri = stack.back(); stack.pop_back();
 			
 			rcRegion& creg = regions[ri];
 
 			spanCount += creg.spanCount;
-			trace.push(ri);
+			trace.push_back(ri);
 
 			for (int j = 0; j < creg.connections.size(); ++j)
 			{
@@ -904,7 +904,7 @@ static bool mergeAndFilterRegions(rcContext* ctx, int minRegionArea, int mergeRe
 				if (neireg.id == 0 || (neireg.id & RC_BORDER_REG))
 					continue;
 				// Visit
-				stack.push(neireg.id);
+				stack.push_back(neireg.id);
 				neireg.visited = true;
 			}
 		}
@@ -1026,7 +1026,7 @@ static bool mergeAndFilterRegions(rcContext* ctx, int minRegionArea, int mergeRe
 	// Return regions that we found to be overlapping.
 	for (int i = 0; i < nreg; ++i)
 		if (regions[i].overlap)
-			overlaps.push(regions[i].id);
+			overlaps.push_back(regions[i].id);
 
 	return true;
 }
@@ -1037,7 +1037,7 @@ static void addUniqueConnection(rcRegion& reg, int n)
 	for (int i = 0; i < reg.connections.size(); ++i)
 		if (reg.connections[i] == n)
 			return;
-	reg.connections.push(n);
+	reg.connections.push_back(n);
 }
 
 static bool mergeAndFilterLayerRegions(rcContext* ctx, int minRegionArea,
@@ -1060,7 +1060,7 @@ static bool mergeAndFilterLayerRegions(rcContext* ctx, int minRegionArea,
 		regions.push_back(rcRegion((unsigned short) i));
 	
 	// Find region neighbours and overlapping regions.
-	rcIntArray lregs(32);
+	rcTempVector<int> lregs(32);
 	for (int y = 0; y < h; ++y)
 	{
 		for (int x = 0; x < w; ++x)
@@ -1084,7 +1084,7 @@ static bool mergeAndFilterLayerRegions(rcContext* ctx, int minRegionArea,
 				reg.ymax = rcMax(reg.ymax, s.y);
 				
 				// Collect all region layers.
-				lregs.push(ri);
+				lregs.push_back(ri);
 				
 				// Update neighbours
 				for (int dir = 0; dir < 4; ++dir)
@@ -1129,7 +1129,7 @@ static bool mergeAndFilterLayerRegions(rcContext* ctx, int minRegionArea,
 		regions[i].id = 0;
 
 	// Merge montone regions to create non-overlapping areas.
-	rcIntArray stack(32);
+	rcTempVector<int> stack(32);
 	for (int i = 1; i < nreg; ++i)
 	{
 		rcRegion& root = regions[i];
@@ -1141,7 +1141,7 @@ static bool mergeAndFilterLayerRegions(rcContext* ctx, int minRegionArea,
 		root.id = layerId;
 
 		stack.clear();
-		stack.push(i);
+		stack.push_back(i);
 		
 		while (stack.size() > 0)
 		{
@@ -1176,7 +1176,7 @@ static bool mergeAndFilterLayerRegions(rcContext* ctx, int minRegionArea,
 					continue;
 					
 				// Deepen
-				stack.push(nei);
+				stack.push_back(nei);
 					
 				// Mark layer id
 				regn.id = layerId;
@@ -1397,7 +1397,7 @@ bool rcBuildRegionsMonotone(rcContext* ctx, rcCompactHeightfield& chf,
 
 	chf.borderSize = borderSize;
 	
-	rcIntArray prev(256);
+	rcTempVector<int> prev(256);
 
 	// Sweep one line at a time.
 	for (int y = borderSize; y < h-borderSize; ++y)
@@ -1493,7 +1493,7 @@ bool rcBuildRegionsMonotone(rcContext* ctx, rcCompactHeightfield& chf,
 		rcScopedTimer timerFilter(ctx, RC_TIMER_BUILD_REGIONS_FILTER);
 
 		// Merge regions and filter out small regions.
-		rcIntArray overlaps;
+		rcTempVector<int> overlaps;
 		chf.maxRegions = id;
 		if (!mergeAndFilterRegions(ctx, minRegionArea, mergeRegionArea, chf.maxRegions, chf, srcReg, overlaps))
 			return false;
@@ -1643,7 +1643,7 @@ bool rcBuildRegions(rcContext* ctx, rcCompactHeightfield& chf,
 		rcScopedTimer timerFilter(ctx, RC_TIMER_BUILD_REGIONS_FILTER);
 
 		// Merge regions and filter out small regions.
-		rcIntArray overlaps;
+		rcTempVector<int> overlaps;
 		chf.maxRegions = regionId;
 		if (!mergeAndFilterRegions(ctx, minRegionArea, mergeRegionArea, chf.maxRegions, chf, srcReg, overlaps))
 			return false;
@@ -1706,7 +1706,7 @@ bool rcBuildLayerRegions(rcContext* ctx, rcCompactHeightfield& chf,
 
 	chf.borderSize = borderSize;
 	
-	rcIntArray prev(256);
+	rcTempVector<int> prev(256);
 	
 	// Sweep one line at a time.
 	for (int y = borderSize; y < h-borderSize; ++y)


### PR DESCRIPTION
`rcIntArray` was the older dynamic array implementation that now is just a wrapper for `rcTempVector`.  It's been marked deprecated in favor of `rcTempVector`.  

This change replaces the remaining instances of `rcIntArray` with `rcTempVector` and removes the `rcIntArray` implementation.