### PR TITLE
Added explicit dtNavMesh::teardown() function to allow in-place reuse…

### DIFF
--- a/Detour/Include/DetourNavMesh.h
+++ b/Detour/Include/DetourNavMesh.h
@@ -356,6 +356,9 @@ public:
 	/// @return The status flags for the operation.
 	///  @see dtCreateNavMeshData
 	dtStatus init(unsigned char* data, const int dataSize, const int flags);
+
+	/// Resets the state of the navmesh instance, and frees all owned memory.
+	void teardown();
 	
 	/// The navigation mesh initialization params.
 	const dtNavMeshParams* getParams() const;

--- a/Detour/Source/DetourNavMesh.cpp
+++ b/Detour/Source/DetourNavMesh.cpp
@@ -208,17 +208,7 @@ dtNavMesh::dtNavMesh() :
 
 dtNavMesh::~dtNavMesh()
 {
-	for (int i = 0; i < m_maxTiles; ++i)
-	{
-		if (m_tiles[i].flags & DT_TILE_FREE_DATA)
-		{
-			dtFree(m_tiles[i].data);
-			m_tiles[i].data = 0;
-			m_tiles[i].dataSize = 0;
-		}
-	}
-	dtFree(m_posLookup);
-	dtFree(m_tiles);
+	teardown();
 }
 		
 dtStatus dtNavMesh::init(const dtNavMeshParams* params)
@@ -289,6 +279,22 @@ dtStatus dtNavMesh::init(unsigned char* data, const int dataSize, const int flag
 		return status;
 
 	return addTile(data, dataSize, flags, 0, 0);
+}
+
+void dtNavMesh::teardown()
+{
+	for (int i = 0; i < m_maxTiles; ++i)
+	{
+		if (m_tiles[i].flags & DT_TILE_FREE_DATA)
+		{
+			dtFree(m_tiles[i].data);
+			m_tiles[i].data = 0;
+			m_tiles[i].dataSize = 0;
+		}
+	}
+	m_maxTiles = 0;
+	dtFree(m_posLookup);
+	dtFree(m_tiles);
 }
 
 /// @par

--- a/Detour/Source/DetourNavMesh.cpp
+++ b/Detour/Source/DetourNavMesh.cpp
@@ -294,7 +294,9 @@ void dtNavMesh::teardown()
 	}
 	m_maxTiles = 0;
 	dtFree(m_posLookup);
+	m_posLookup = 0;
 	dtFree(m_tiles);
+	m_tiles = 0;
 }
 
 /// @par


### PR DESCRIPTION
… of instances.

For cases where you want reuse and want to avoid dynamic allocation, this helps avoid workarounds such as using an `alignas()` buffer of char + placement new / explicit dtor.