### PR TITLE
Make RECASTNAVIGATION_ENABLE_ASSERTS do what it looks like it does

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ option(RECASTNAVIGATION_TESTS "Build tests" ON)
 option(RECASTNAVIGATION_EXAMPLES "Build examples" ON)
 option(RECASTNAVIGATION_DT_POLYREF64 "Use 64bit polyrefs instead of 32bit for Detour" OFF)
 option(RECASTNAVIGATION_DT_VIRTUAL_QUERYFILTER "Use dynamic dispatch for dtQueryFilter in Detour to allow for custom filters" OFF)
-option(RECASTNAVIGATION_ENABLE_ASSERTS "Enable custom recastnavigation asserts" "$<IF:$<CONFIG:Debug>,ON,OFF>")
+set(RECASTNAVIGATION_ENABLE_ASSERTS "$<CONFIG:Debug>" CACHE STRING "Condition to enable custom recastnavigation asserts, evaluated as generator expression")
 option(RECASTNAVIGATION_ENABLE_FAST_MATH "Enable faster math calculations." OFF)
 
 # dll export
@@ -61,9 +61,6 @@ set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "$<$<CONFIG:Debug,RelWithDebInfo>:Progra
 if(NOT MSVC)
     add_compile_options(-g)
 endif()
-
-# Release optimizations and disable asserts
-add_compile_definitions($<$<NOT:$<CONFIG:Debug>>:RC_DISABLE_ASSERTS>)
 
 configure_file(
     "${RecastNavigation_SOURCE_DIR}/version.h.in"

--- a/Detour/CMakeLists.txt
+++ b/Detour/CMakeLists.txt
@@ -22,9 +22,7 @@ if (RECASTNAVIGATION_DT_VIRTUAL_QUERYFILTER)
     target_compile_definitions(Detour PUBLIC DT_VIRTUAL_QUERYFILTER)
 endif()
 
-if (NOT RECASTNAVIGATION_ENABLE_ASSERTS)
-    target_compile_definitions(Detour PUBLIC RC_DISABLE_ASSERTS)
-endif()
+target_compile_definitions(Detour PUBLIC "$<$<NOT:${RECASTNAVIGATION_ENABLE_ASSERTS}>:RC_DISABLE_ASSERTS>")
 
 # Set include path
 set(Detour_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Include")

--- a/Recast/CMakeLists.txt
+++ b/Recast/CMakeLists.txt
@@ -19,9 +19,7 @@ target_include_directories(Recast PUBLIC
     "$<BUILD_INTERFACE:${Recast_INCLUDE_DIR}>"
 )
 
-if (NOT RECASTNAVIGATION_ENABLE_ASSERTS)
-    target_compile_definitions(Recast PUBLIC RC_DISABLE_ASSERTS)
-endif()
+target_compile_definitions(Recast PUBLIC "$<$<NOT:${RECASTNAVIGATION_ENABLE_ASSERTS}>:RC_DISABLE_ASSERTS>")
 
 install(TARGETS Recast
     EXPORT recastnavigation-targets


### PR DESCRIPTION
There were some flaws with the existing implementation. Effectively, they meant that `RC_DISABLE_ASSERTS` was always defined unless someone explicitly set `RECASTNAVIGATION_ENABLE_ASSERTS` to one of CMake's truthy values.

* `option` only sets boolean options, so the `"$<IF:$<CONFIG:Debug>,ON,OFF>"` string was immediately converted to `OFF` as it's not literally *`1`, `ON`, `YES`, `TRUE`, `Y`, or a non-zero number*. Non-boolean options need to be declared with the `set` command in `CACHE` mode.
* Even if it *had* kept it as a string, it was fed to `if(NOT ...)`, which would have converted it to a boolean via the same rules. If you're using generator expressions, they can't be used for control flow, and must remain as strings until they're fed to a command that interprets them, and even then, that's deferred until after the `CMakeLists.txt` has fully executed and the configure phase is over and the generation phase has started.
* It's still slightly awkward as it needs negating in the place where it's used.

It's still got to be propagated to targets that consume recastnavigation as it's used in `RecastAlloc.h`, and there might be ODR violations if they use the templates that file defines with the preprocessor definition set differently. That can be a pain as if someone needs to toggle this to investigate an issue, it'll mean recompiling a whole game engine instead of just recast and the one or two translation units that include that header. It *might* be worth moving `rcVectorBase` and its derivatives to their own private header that's part of the build interface but not the install interface (and doing the same for the bits of the headers that define `dtAssert` and `rcAssert`), but I'm not doing that here as I'm just fixing something that already exists.